### PR TITLE
Save single filter

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -33,6 +33,7 @@ import { SavedQueriesItem } from './saved_queries_item';
 import { FilterExpressionItem } from './filter_expression_item';
 
 import { UI_SETTINGS } from '../../../common';
+import { FilterBarContext } from './filter_bar_context';
 
 interface Props {
   filters: Filter[];
@@ -46,6 +47,9 @@ interface Props {
   selectedSavedQueries?: SavedQuery[];
   removeSelectedSavedQuery: (savedQuery: SavedQuery) => void;
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
+  openFilterExpressionPopover: boolean;
+  toggleFilterExpressionPopover: (value: boolean) => void;
+  saveQueryFormComponent: JSX.Element;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -279,15 +283,24 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
   // }
 
   const classes = classNames('globalFilterBar', props.className);
+  const { openFilterExpressionPopover, toggleFilterExpressionPopover, saveQueryFormComponent } =
+    props;
 
   return (
-    <EuiFlexGroup
-      className="globalFilterGroup"
-      gutterSize="none"
-      alignItems="flexStart"
-      responsive={false}
+    <FilterBarContext.Provider
+      value={{
+        openFilterExpressionPopover,
+        toggleFilterExpressionPopover,
+        saveQueryFormComponent,
+      }}
     >
-      {/* <EuiFlexItem className="globalFilterGroup__branch" grow={false}>
+      <EuiFlexGroup
+        className="globalFilterGroup"
+        gutterSize="none"
+        alignItems="flexStart"
+        responsive={false}
+      >
+        {/* <EuiFlexItem className="globalFilterGroup__branch" grow={false}>
         <FilterOptions
           onEnableAll={onEnableAll}
           onDisableAll={onDisableAll}
@@ -299,23 +312,24 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
         />
       </EuiFlexItem> */}
 
-      <EuiFlexItem className="globalFilterGroup__filterFlexItem">
-        <EuiFlexGroup
-          ref={groupRef}
-          className={classes}
-          wrap={true}
-          responsive={false}
-          gutterSize="xs"
-          alignItems="center"
-          tabIndex={-1}
-        >
-          {renderMultipleFilters()}
-          {renderSelectedSavedQueries()}
-          {props.multipleFilters.length === 0 && renderItems()}
-          {/* {renderAddFilter()} */}
-        </EuiFlexGroup>
-      </EuiFlexItem>
-    </EuiFlexGroup>
+        <EuiFlexItem className="globalFilterGroup__filterFlexItem">
+          <EuiFlexGroup
+            ref={groupRef}
+            className={classes}
+            wrap={true}
+            responsive={false}
+            gutterSize="xs"
+            alignItems="center"
+            tabIndex={-1}
+          >
+            {renderMultipleFilters()}
+            {renderSelectedSavedQueries()}
+            {props.multipleFilters.length === 0 && renderItems()}
+            {/* {renderAddFilter()} */}
+          </EuiFlexGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </FilterBarContext.Provider>
   );
 });
 

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -34,6 +34,8 @@ import { FilterExpressionItem } from './filter_expression_item';
 
 import { UI_SETTINGS } from '../../../common';
 import { FilterBarContext } from './filter_bar_context';
+import { SavedQueryMeta } from '../saved_query_form';
+import { SavedQueryService } from '../..';
 
 interface Props {
   filters: Filter[];
@@ -47,9 +49,8 @@ interface Props {
   selectedSavedQueries?: SavedQuery[];
   removeSelectedSavedQuery: (savedQuery: SavedQuery) => void;
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
-  openFilterExpressionPopover: boolean;
-  toggleFilterExpressionPopover: (value: boolean) => void;
-  saveQueryFormComponent: JSX.Element;
+  savedQueryService: SavedQueryService;
+  onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -283,15 +284,13 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
   // }
 
   const classes = classNames('globalFilterBar', props.className);
-  const { openFilterExpressionPopover, toggleFilterExpressionPopover, saveQueryFormComponent } =
-    props;
+  const { savedQueryService, onFilterSave } = props;
 
   return (
     <FilterBarContext.Provider
       value={{
-        openFilterExpressionPopover,
-        toggleFilterExpressionPopover,
-        saveQueryFormComponent,
+        savedQueryService,
+        onFilterSave,
       }}
     >
       <EuiFlexGroup

--- a/src/plugins/data/public/ui/filter_bar/filter_bar_context.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar_context.tsx
@@ -7,11 +7,12 @@
  */
 
 import React from 'react';
+import { SavedQueryService } from '../..';
+import { SavedQueryMeta } from '../saved_query_form';
 
 export interface IFilterBarContext {
-  openFilterExpressionPopover: boolean;
-  toggleFilterExpressionPopover: (value: boolean) => void;
-  saveQueryFormComponent: JSX.Element;
+  savedQueryService: SavedQueryService;
+  onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
 }
 
 const defaultContext = {} as unknown as IFilterBarContext;

--- a/src/plugins/data/public/ui/filter_bar/filter_bar_context.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar_context.tsx
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+export interface IFilterBarContext {
+  openFilterExpressionPopover: boolean;
+  toggleFilterExpressionPopover: (value: boolean) => void;
+  saveQueryFormComponent: JSX.Element;
+}
+
+const defaultContext = {} as unknown as IFilterBarContext;
+
+export const FilterBarContext = React.createContext<IFilterBarContext>(defaultContext);

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -23,6 +23,7 @@ import { existsOperator, isOneOfOperator } from './filter_editor/lib/filter_oper
 import { IIndexPattern } from '../..';
 import { getDisplayValueFromFilter, getIndexPatternFromFilter } from '../../query';
 import { FilterBarContext } from './filter_bar_context';
+import { SaveQueryForm } from '../saved_query_form';
 
 const FILTER_ITEM_OK = '';
 const FILTER_ITEM_WARNING = 'warn';
@@ -58,17 +59,15 @@ export const FilterExpressionItem: FC<Props> = ({
   filtersGroupsCount,
   onUpdate,
 }: Props) => {
-  // const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
-  const { openFilterExpressionPopover, toggleFilterExpressionPopover, saveQueryFormComponent } =
-    useContext(FilterBarContext);
+  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  const { savedQueryService, onFilterSave } = useContext(FilterBarContext);
   function handleBadgeClick() {
     // if (e.shiftKey) {
     //   onToggleDisabled();
     // } else {
     //   setIsPopoverOpen(!isPopoverOpen);
     // }
-    toggleFilterExpressionPopover(!openFilterExpressionPopover);
-    // setIsPopoverOpen(!isPopoverOpen);
+    setIsPopoverOpen(!isPopoverOpen);
   }
 
   function onDuplicate() {
@@ -109,8 +108,7 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'invert',
         onClick: () => {
-          toggleFilterExpressionPopover(false);
-          // setIsPopoverOpen(false);
+          setIsPopoverOpen(false);
           onToggleNegated();
         },
         'data-test-subj': 'negateFilter',
@@ -121,8 +119,7 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'copy',
         onClick: () => {
-          toggleFilterExpressionPopover(false);
-          // setIsPopoverOpen(false);
+          setIsPopoverOpen(false);
           onDuplicate();
         },
         'data-test-subj': 'negateFilter',
@@ -137,8 +134,7 @@ export const FilterExpressionItem: FC<Props> = ({
             }),
         icon: `${groupedFilters[0].meta.disabled ? 'eye' : 'eyeClosed'}`,
         onClick: () => {
-          toggleFilterExpressionPopover(false);
-          // setIsPopoverOpen(false);
+          setIsPopoverOpen(false);
           onToggleDisabled();
         },
         'data-test-subj': 'disableFilter',
@@ -157,8 +153,7 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'trash',
         onClick: () => {
-          toggleFilterExpressionPopover(false);
-          // setIsPopoverOpen(false);
+          setIsPopoverOpen(false);
           onRemove(groupId);
         },
         'data-test-subj': 'deleteFilter',
@@ -175,7 +170,20 @@ export const FilterExpressionItem: FC<Props> = ({
         title: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
           defaultMessage: `Save as filter`,
         }),
-        content: <div style={{ padding: 16 }}>{saveQueryFormComponent}</div>,
+        content: (
+          <div style={{ padding: 16 }}>
+            <SaveQueryForm
+              savedQueryService={savedQueryService}
+              onSave={(savedQueryMeta) => {
+                onFilterSave(savedQueryMeta, true);
+                setIsPopoverOpen(false);
+              }}
+              onClose={() => setIsPopoverOpen(false)}
+              showTimeFilterOption={false}
+              showFilterOption={false}
+            />
+          </div>
+        ),
       },
       // {
       //   id: 1,
@@ -440,10 +448,9 @@ export const FilterExpressionItem: FC<Props> = ({
   return (
     <EuiPopover
       id={`popoverFor_filter${groupId}`}
-      isOpen={openFilterExpressionPopover}
+      isOpen={isPopoverOpen}
       closePopover={() => {
-        toggleFilterExpressionPopover(false);
-        // setIsPopoverOpen(false);
+        setIsPopoverOpen(false);
       }}
       button={badge}
       panelPaddingSize="none"

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -16,12 +16,13 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { groupBy } from 'lodash';
-import React, { FC, useState } from 'react';
+import React, { FC, useContext, useState } from 'react';
 import { Filter, toggleFilterDisabled } from '@kbn/es-query';
 import { FILTERS } from '../../../common';
 import { existsOperator, isOneOfOperator } from './filter_editor/lib/filter_operators';
 import { IIndexPattern } from '../..';
 import { getDisplayValueFromFilter, getIndexPatternFromFilter } from '../../query';
+import { FilterBarContext } from './filter_bar_context';
 
 const FILTER_ITEM_OK = '';
 const FILTER_ITEM_WARNING = 'warn';
@@ -57,14 +58,17 @@ export const FilterExpressionItem: FC<Props> = ({
   filtersGroupsCount,
   onUpdate,
 }: Props) => {
-  const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  // const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  const { openFilterExpressionPopover, toggleFilterExpressionPopover, saveQueryFormComponent } =
+    useContext(FilterBarContext);
   function handleBadgeClick() {
     // if (e.shiftKey) {
     //   onToggleDisabled();
     // } else {
     //   setIsPopoverOpen(!isPopoverOpen);
     // }
-    setIsPopoverOpen(!isPopoverOpen);
+    toggleFilterExpressionPopover(!openFilterExpressionPopover);
+    // setIsPopoverOpen(!isPopoverOpen);
   }
 
   function onDuplicate() {
@@ -105,7 +109,8 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'invert',
         onClick: () => {
-          setIsPopoverOpen(false);
+          toggleFilterExpressionPopover(false);
+          // setIsPopoverOpen(false);
           onToggleNegated();
         },
         'data-test-subj': 'negateFilter',
@@ -116,7 +121,8 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'copy',
         onClick: () => {
-          setIsPopoverOpen(false);
+          toggleFilterExpressionPopover(false);
+          // setIsPopoverOpen(false);
           onDuplicate();
         },
         'data-test-subj': 'negateFilter',
@@ -131,10 +137,19 @@ export const FilterExpressionItem: FC<Props> = ({
             }),
         icon: `${groupedFilters[0].meta.disabled ? 'eye' : 'eyeClosed'}`,
         onClick: () => {
-          setIsPopoverOpen(false);
+          toggleFilterExpressionPopover(false);
+          // setIsPopoverOpen(false);
           onToggleDisabled();
         },
         'data-test-subj': 'disableFilter',
+      },
+      {
+        name: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
+          defaultMessage: `Save as filter`,
+        }),
+        icon: 'save',
+        panel: 2,
+        'data-test-subj': 'saveAsFilter',
       },
       {
         name: i18n.translate('data.filter.filterBar.deleteFilterButtonLabel', {
@@ -142,7 +157,8 @@ export const FilterExpressionItem: FC<Props> = ({
         }),
         icon: 'trash',
         onClick: () => {
-          setIsPopoverOpen(false);
+          toggleFilterExpressionPopover(false);
+          // setIsPopoverOpen(false);
           onRemove(groupId);
         },
         'data-test-subj': 'deleteFilter',
@@ -153,6 +169,13 @@ export const FilterExpressionItem: FC<Props> = ({
       {
         id: 0,
         items: mainPanelItems,
+      },
+      {
+        id: 2,
+        title: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
+          defaultMessage: `Save as filter`,
+        }),
+        content: <div style={{ padding: 16 }}>{saveQueryFormComponent}</div>,
       },
       // {
       //   id: 1,
@@ -417,9 +440,10 @@ export const FilterExpressionItem: FC<Props> = ({
   return (
     <EuiPopover
       id={`popoverFor_filter${groupId}`}
-      isOpen={isPopoverOpen}
+      isOpen={openFilterExpressionPopover}
       closePopover={() => {
-        setIsPopoverOpen(false);
+        toggleFilterExpressionPopover(false);
+        // setIsPopoverOpen(false);
       }}
       button={badge}
       panelPaddingSize="none"

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -110,6 +110,7 @@ interface State {
   showSaveQueryModal: boolean;
   showSaveNewQueryModal: boolean;
   openFilterSetPopover: boolean;
+  openFilterExpressionPopover: boolean;
   showSavedQueryPopover: boolean;
   selectedSavedQueries: SavedQuery[];
   finalSelectedSavedQueries: SavedQuery[];
@@ -199,6 +200,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     showSaveQueryModal: false,
     showSaveNewQueryModal: false,
     openFilterSetPopover: false,
+    openFilterExpressionPopover: false,
     showSavedQueryPopover: false,
     currentProps: this.props,
     selectedSavedQueries: [],
@@ -306,6 +308,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         showSaveQueryModal: false,
         showSaveNewQueryModal: false,
         openFilterSetPopover: false,
+        openFilterExpressionPopover: false,
       });
 
       if (this.props.onSaved) {
@@ -530,6 +533,12 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     });
   };
 
+  public toggleFilterExpressionPopover = (value: boolean) => {
+    this.setState({
+      openFilterExpressionPopover: value,
+    });
+  };
+
   public render() {
     const savedQueryManagement = this.state.query && this.props.onClearSavedQuery && (
       <SavedQueryManagementComponent
@@ -546,13 +555,19 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       </SavedQueryManagementComponent>
     );
 
-    const saveQueryFormComponent = (
+    const saveQueryFormComponent = (timeFilterOption?: boolean) => (
       <SaveQueryForm
         savedQueryService={this.savedQueryService}
         onSave={(savedQueryMeta) => this.onSave(savedQueryMeta, true)}
-        onClose={() => this.setState({ openFilterSetPopover: false })}
+        onClose={() =>
+          this.setState({ openFilterSetPopover: false, openFilterExpressionPopover: false })
+        }
         showFilterOption={this.props.showFilterBar}
-        showTimeFilterOption={this.shouldRenderTimeFilterInSavedQueryForm()}
+        showTimeFilterOption={
+          timeFilterOption === undefined
+            ? this.shouldRenderTimeFilterInSavedQueryForm()
+            : timeFilterOption
+        }
       />
     );
 
@@ -572,7 +587,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         toggleAddFilterModal={this.toggleAddFilterModal}
         savedQueryService={this.savedQueryService}
         applySelectedQuery={this.applySelectedQuery}
-        saveQueryFormComponent={saveQueryFormComponent}
+        saveQueryFormComponent={saveQueryFormComponent()}
         toggleFilterSetPopover={this.toggleFilterSetPopover}
         openFilterSetPopover={this.state.openFilterSetPopover}
       />
@@ -695,6 +710,9 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             removeSelectedSavedQuery={this.removeSelectedSavedQuery}
             onMultipleFiltersUpdated={this.onMultipleFiltersUpdated}
             multipleFilters={this.state.multipleFilters}
+            openFilterExpressionPopover={this.state.openFilterExpressionPopover}
+            toggleFilterExpressionPopover={this.toggleFilterExpressionPopover}
+            saveQueryFormComponent={saveQueryFormComponent(false)}
           />
         </div>
       );

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -110,7 +110,6 @@ interface State {
   showSaveQueryModal: boolean;
   showSaveNewQueryModal: boolean;
   openFilterSetPopover: boolean;
-  openFilterExpressionPopover: boolean;
   showSavedQueryPopover: boolean;
   selectedSavedQueries: SavedQuery[];
   finalSelectedSavedQueries: SavedQuery[];
@@ -200,7 +199,6 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     showSaveQueryModal: false,
     showSaveNewQueryModal: false,
     openFilterSetPopover: false,
-    openFilterExpressionPopover: false,
     showSavedQueryPopover: false,
     currentProps: this.props,
     selectedSavedQueries: [],
@@ -308,7 +306,6 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         showSaveQueryModal: false,
         showSaveNewQueryModal: false,
         openFilterSetPopover: false,
-        openFilterExpressionPopover: false,
       });
 
       if (this.props.onSaved) {
@@ -533,12 +530,6 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     });
   };
 
-  public toggleFilterExpressionPopover = (value: boolean) => {
-    this.setState({
-      openFilterExpressionPopover: value,
-    });
-  };
-
   public render() {
     const savedQueryManagement = this.state.query && this.props.onClearSavedQuery && (
       <SavedQueryManagementComponent
@@ -555,19 +546,13 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       </SavedQueryManagementComponent>
     );
 
-    const saveQueryFormComponent = (timeFilterOption?: boolean) => (
+    const saveQueryFormComponent = (
       <SaveQueryForm
         savedQueryService={this.savedQueryService}
         onSave={(savedQueryMeta) => this.onSave(savedQueryMeta, true)}
-        onClose={() =>
-          this.setState({ openFilterSetPopover: false, openFilterExpressionPopover: false })
-        }
+        onClose={() => this.setState({ openFilterSetPopover: false })}
         showFilterOption={this.props.showFilterBar}
-        showTimeFilterOption={
-          timeFilterOption === undefined
-            ? this.shouldRenderTimeFilterInSavedQueryForm()
-            : timeFilterOption
-        }
+        showTimeFilterOption={this.shouldRenderTimeFilterInSavedQueryForm()}
       />
     );
 
@@ -587,7 +572,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         toggleAddFilterModal={this.toggleAddFilterModal}
         savedQueryService={this.savedQueryService}
         applySelectedQuery={this.applySelectedQuery}
-        saveQueryFormComponent={saveQueryFormComponent()}
+        saveQueryFormComponent={saveQueryFormComponent}
         toggleFilterSetPopover={this.toggleFilterSetPopover}
         openFilterSetPopover={this.state.openFilterSetPopover}
       />
@@ -710,9 +695,8 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             removeSelectedSavedQuery={this.removeSelectedSavedQuery}
             onMultipleFiltersUpdated={this.onMultipleFiltersUpdated}
             multipleFilters={this.state.multipleFilters}
-            openFilterExpressionPopover={this.state.openFilterExpressionPopover}
-            toggleFilterExpressionPopover={this.toggleFilterExpressionPopover}
-            saveQueryFormComponent={saveQueryFormComponent(false)}
+            savedQueryService={this.savedQueryService}
+            onFilterSave={this.onSave}
           />
         </div>
       );


### PR DESCRIPTION
## Save as filter option was added to filter expression

Add Save as filter option for filter expression in dashboard search bar
![save-filter](https://user-images.githubusercontent.com/59783836/151311938-552bb1e7-2f7e-458c-a4bd-be680ca6b417.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
