### PR TITLE
Save filter expression and Create filter set with given label name from add filter modal

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -33,6 +33,8 @@ import { SavedQueriesItem } from './saved_queries_item';
 import { FilterExpressionItem } from './filter_expression_item';
 
 import { UI_SETTINGS } from '../../../common';
+import { SavedQueryMeta } from '../saved_query_form';
+import { SavedQueryService } from '../..';
 
 interface Props {
   filters: Filter[];
@@ -46,6 +48,8 @@ interface Props {
   selectedSavedQueries?: SavedQuery[];
   removeSelectedSavedQuery: (savedQuery: SavedQuery) => void;
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
+  savedQueryService: SavedQueryService;
+  onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -110,6 +114,8 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
           onRemove={onRemoveFilterGroup}
           onUpdate={onUpdateFilterGroup}
           filtersGroupsCount={Object.entries(firstDepthGroupedFilters).length}
+          savedQueryService={props.savedQueryService}
+          onFilterSave={props.onFilterSave}
         />
       );
       GroupBadge.push(badge);

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -50,6 +50,7 @@ interface Props {
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
   savedQueryService: SavedQueryService;
   onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
+  onFilterBadgeSaved: (groupId: number, alias: string) => void;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -122,6 +123,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
           filtersGroupsCount={Object.entries(firstDepthGroupedFilters).length}
           savedQueryService={props.savedQueryService}
           onFilterSave={props.onFilterSave}
+          onFilterBadgeSaved={props.onFilterBadgeSaved}
         />
       );
       GroupBadge.push(badge);

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -98,7 +98,13 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
   }
 
   function renderMultipleFilters() {
-    const firstDepthGroupedFilters = groupBy(props.multipleFilters, 'groupId');
+    const groupedByAlias = groupBy(props.multipleFilters, 'meta.alias');
+    const filtersWithoutLabel = groupedByAlias.null || groupedByAlias.undefined;
+    const labels = Object.keys(groupedByAlias).filter(
+      (key) => key !== 'null' && key !== 'undefined'
+    );
+
+    const firstDepthGroupedFilters = groupBy(filtersWithoutLabel, 'groupId');
     const GroupBadge: JSX.Element[] = [];
     for (const [groupId, groupedFilters] of Object.entries(firstDepthGroupedFilters)) {
       const badge = (
@@ -114,6 +120,27 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
       );
       GroupBadge.push(badge);
     }
+
+    let groupId: string;
+    labels.map((label) => {
+      // we should have same groupIds on our labeled filters group
+      groupId = (groupedByAlias[label][0] as any).groupId;
+      groupedByAlias[label].forEach((filter) => ((filter as any).groupId = groupId));
+      const labelBadge = (
+        <FilterExpressionItem
+          groupId={groupId}
+          groupedFilters={groupedByAlias[label]}
+          indexPatterns={props?.indexPatterns}
+          onClick={() => {}}
+          onRemove={onRemoveFilterGroup}
+          onUpdate={onUpdateFilterGroup}
+          filtersGroupsCount={1}
+          customLabel={label}
+        />
+      );
+      GroupBadge.push(labelBadge);
+    });
+
     return GroupBadge;
   }
 

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -50,7 +50,7 @@ interface Props {
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
   savedQueryService: SavedQueryService;
   onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
-  onFilterBadgeSaved: (groupId: number, alias: string) => void;
+  onFilterBadgeSave: (groupId: number, alias: string) => void;
 }
 
 const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
@@ -123,7 +123,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
           filtersGroupsCount={Object.entries(firstDepthGroupedFilters).length}
           savedQueryService={props.savedQueryService}
           onFilterSave={props.onFilterSave}
-          onFilterBadgeSaved={props.onFilterBadgeSaved}
+          onFilterBadgeSave={props.onFilterBadgeSave}
         />
       );
       GroupBadge.push(badge);

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -22,6 +22,8 @@ import { FILTERS } from '../../../common';
 import { existsOperator, isOneOfOperator } from './filter_editor/lib/filter_operators';
 import { IIndexPattern } from '../..';
 import { getDisplayValueFromFilter, getIndexPatternFromFilter } from '../../query';
+import { SavedQueryMeta, SaveQueryForm } from '../saved_query_form';
+import { SavedQueryService } from '../..';
 
 const FILTER_ITEM_OK = '';
 const FILTER_ITEM_WARNING = 'warn';
@@ -46,6 +48,8 @@ interface Props {
   groupId: string;
   filtersGroupsCount: number;
   onUpdate?: (filters: Filter[], groupId: string, toggleNegate: boolean) => void;
+  savedQueryService: SavedQueryService;
+  onFilterSave: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
 }
 
 export const FilterExpressionItem: FC<Props> = ({
@@ -56,6 +60,8 @@ export const FilterExpressionItem: FC<Props> = ({
   groupId,
   filtersGroupsCount,
   onUpdate,
+  savedQueryService,
+  onFilterSave,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   function handleBadgeClick() {
@@ -137,6 +143,14 @@ export const FilterExpressionItem: FC<Props> = ({
         'data-test-subj': 'disableFilter',
       },
       {
+        name: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
+          defaultMessage: `Save as filter`,
+        }),
+        icon: 'save',
+        panel: 2,
+        'data-test-subj': 'saveAsFilter',
+      },
+      {
         name: i18n.translate('data.filter.filterBar.deleteFilterButtonLabel', {
           defaultMessage: `Remove`,
         }),
@@ -153,6 +167,26 @@ export const FilterExpressionItem: FC<Props> = ({
       {
         id: 0,
         items: mainPanelItems,
+      },
+      {
+        id: 2,
+        title: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
+          defaultMessage: `Save as filter`,
+        }),
+        content: (
+          <div style={{ padding: 16 }}>
+            <SaveQueryForm
+              savedQueryService={savedQueryService}
+              onSave={(savedQueryMeta) => {
+                onFilterSave(savedQueryMeta, true);
+                setIsPopoverOpen(false);
+              }}
+              onClose={() => setIsPopoverOpen(false)}
+              showTimeFilterOption={false}
+              showFilterOption={false}
+            />
+          </div>
+        ),
       },
       // {
       //   id: 1,

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -13,6 +13,7 @@ import {
   EuiTextColor,
   EuiPopover,
   EuiContextMenu,
+  EuiIcon,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { groupBy } from 'lodash';
@@ -46,6 +47,7 @@ interface Props {
   groupId: string;
   filtersGroupsCount: number;
   onUpdate?: (filters: Filter[], groupId: string, toggleNegate: boolean) => void;
+  customLabel?: string;
 }
 
 export const FilterExpressionItem: FC<Props> = ({
@@ -56,6 +58,7 @@ export const FilterExpressionItem: FC<Props> = ({
   groupId,
   filtersGroupsCount,
   onUpdate,
+  customLabel,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   function handleBadgeClick() {
@@ -406,9 +409,16 @@ export const FilterExpressionItem: FC<Props> = ({
         onClick={handleBadgeClick}
       >
         <div ref={ref}>
-          {filterExpression.map((expression) => {
-            return <>{expression}</>;
-          })}
+          {customLabel ? (
+            <>
+              <EuiIcon type="save" />
+              {customLabel}
+            </>
+          ) : (
+            filterExpression.map((expression) => {
+              return <>{expression}</>;
+            })
+          )}
         </div>
       </EuiBadge>
     </EuiFlexItem>

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -53,7 +53,7 @@ interface Props {
   savedQueryService?: SavedQueryService;
   onFilterSave?: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
   customLabel?: string;
-  onFilterBadgeSaved?: (groupId: number, alias: string) => void;
+  onFilterBadgeSave?: (groupId: number, alias: string) => void;
 }
 
 export const FilterExpressionItem: FC<Props> = ({
@@ -67,7 +67,7 @@ export const FilterExpressionItem: FC<Props> = ({
   savedQueryService,
   onFilterSave,
   customLabel,
-  onFilterBadgeSaved,
+  onFilterBadgeSave,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const filters: Filter[] = groupedFilters.map((filter: Filter) => ({
@@ -190,7 +190,7 @@ export const FilterExpressionItem: FC<Props> = ({
       // },
     ];
 
-    if (!customLabel && savedQueryService && onFilterSave && onFilterBadgeSaved) {
+    if (!customLabel && savedQueryService && onFilterSave && onFilterBadgeSave) {
       const saveAsFilterPanelItem = {
         name: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
           defaultMessage: `Save as filter`,
@@ -217,7 +217,7 @@ export const FilterExpressionItem: FC<Props> = ({
               showTimeFilterOption={false}
               showFilterOption={false}
               filters={filters}
-              onFilterBadgeSaved={(alias: string) => onFilterBadgeSaved(Number(groupId), alias)}
+              onFilterBadgeSave={(alias: string) => onFilterBadgeSave(Number(groupId), alias)}
             />
           </div>
         ),

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -64,6 +64,11 @@ export const FilterExpressionItem: FC<Props> = ({
   onFilterSave,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
+  const filters: Filter[] = groupedFilters.map((filter: Filter) => ({
+    $state: filter.$state,
+    meta: filter.meta,
+    query: filter.query,
+  }));
   function handleBadgeClick() {
     // if (e.shiftKey) {
     //   onToggleDisabled();
@@ -184,6 +189,7 @@ export const FilterExpressionItem: FC<Props> = ({
               onClose={() => setIsPopoverOpen(false)}
               showTimeFilterOption={false}
               showFilterOption={false}
+              filters={filters}
             />
           </div>
         ),

--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -53,6 +53,7 @@ interface Props {
   savedQueryService?: SavedQueryService;
   onFilterSave?: (savedQueryMeta: SavedQueryMeta, saveAsNew?: boolean) => Promise<void>;
   customLabel?: string;
+  onFilterBadgeSaved?: (groupId: number, alias: string) => void;
 }
 
 export const FilterExpressionItem: FC<Props> = ({
@@ -66,6 +67,7 @@ export const FilterExpressionItem: FC<Props> = ({
   savedQueryService,
   onFilterSave,
   customLabel,
+  onFilterBadgeSaved,
 }: Props) => {
   const [isPopoverOpen, setIsPopoverOpen] = useState<boolean>(false);
   const filters: Filter[] = groupedFilters.map((filter: Filter) => ({
@@ -188,7 +190,7 @@ export const FilterExpressionItem: FC<Props> = ({
       // },
     ];
 
-    if (!customLabel && savedQueryService && onFilterSave) {
+    if (!customLabel && savedQueryService && onFilterSave && onFilterBadgeSaved) {
       const saveAsFilterPanelItem = {
         name: i18n.translate('data.filter.filterBar.saveAsFilterButtonLabel', {
           defaultMessage: `Save as filter`,
@@ -215,6 +217,7 @@ export const FilterExpressionItem: FC<Props> = ({
               showTimeFilterOption={false}
               showFilterOption={false}
               filters={filters}
+              onFilterBadgeSaved={(alias: string) => onFilterBadgeSaved(Number(groupId), alias)}
             />
           </div>
         ),

--- a/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
@@ -51,6 +51,7 @@ import { GenericComboBox } from '../filter_bar/filter_editor/generic_combo_box';
 import { PhraseValueInput } from '../filter_bar/filter_editor/phrase_value_input';
 import { PhrasesValuesInput } from '../filter_bar/filter_editor/phrases_values_input';
 import { RangeValueInput } from '../filter_bar/filter_editor/range_value_input';
+import { SavedQueryMeta } from '../saved_query_form';
 
 import { IIndexPattern, IFieldType } from '../..';
 
@@ -95,6 +96,7 @@ export function AddFilterModal({
   timeRangeForSuggestionsOverride,
   savedQueryManagement,
   initialAddFilterMode,
+  saveFilters,
 }: {
   onSubmit: (filters: Filter[]) => void;
   onMultipleFiltersSubmit: (filters: FilterGroup[], buildFilters: Filter[]) => void;
@@ -105,6 +107,7 @@ export function AddFilterModal({
   timeRangeForSuggestionsOverride?: boolean;
   savedQueryManagement?: JSX.Element;
   initialAddFilterMode?: string;
+  saveFilters: (savedQueryMeta: SavedQueryMeta) => void;
 }) {
   const [selectedIndexPattern, setSelectedIndexPattern] = useState(
     getIndexPatternFromFilter(filter, indexPatterns)
@@ -367,6 +370,13 @@ export function AddFilterModal({
         $state.store
       );
       onSubmit([builtCustomFilter]);
+      saveFilters({
+        title: customLabel,
+        description: '',
+        shouldIncludeFilters: false,
+        shouldIncludeTimefilter: false,
+        filters: [builtCustomFilter],
+      });
     } else if (addFilterMode === 'quick_form' && selectedIndexPattern) {
       const builtFilters = localFilters.map((localFilter) => {
         if (localFilter.field && localFilter.operator) {
@@ -388,6 +398,15 @@ export function AddFilterModal({
         ) as Filter[];
         // onSubmit(finalFilters);
         onMultipleFiltersSubmit(localFilters, finalFilters);
+        if (alias) {
+          saveFilters({
+            title: customLabel,
+            description: '',
+            shouldIncludeFilters: false,
+            shouldIncludeTimefilter: false,
+            filters: finalFilters,
+          });
+        }
       }
     } else if (addFilterMode === 'saved_filters') {
       applySavedQueries();

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -49,6 +49,7 @@ const QueryStringInput = withKibana(QueryStringInputUI);
 // @internal
 export interface QueryBarTopRowProps {
   filters: Filter[];
+  multipleFilters: Filter[];
   onFiltersUpdated?: (filters: Filter[]) => void;
   onMultipleFiltersUpdated?: (filters: Filter[]) => void;
   applySelectedSavedQueries?: () => void;
@@ -394,18 +395,26 @@ export const QueryBarTopRow = React.memo(
     }
 
     function onAddMultipleFiltersANDOR(selectedFilters: FilterGroup[], buildFilters: Filter[]) {
+      const lastFilter: any = props.multipleFilters[props.multipleFilters.length - 1];
       const mappedFilters = mapAndFlattenFilters(buildFilters);
       const mergedFilters = mappedFilters.map((filter, idx) => {
+        let groupId = selectedFilters[idx].groupId;
+        // given 1 + last undefined  -> 1
+        // given 2 + last 1 -> 3
+
+        if (lastFilter !== undefined) groupId = selectedFilters[idx].groupId + lastFilter.groupId;
+
         return {
           ...filter,
-          groupId: selectedFilters[idx].groupId,
+          groupId,
           id: selectedFilters[idx].id,
           relationship: selectedFilters[idx].relationship,
           subGroupId: selectedFilters[idx].subGroupId,
         };
       });
       props.toggleAddFilterModal?.(false);
-      props?.onMultipleFiltersUpdated?.(mergedFilters);
+      props?.onMultipleFiltersUpdated?.([...props.multipleFilters, ...mergedFilters]);
+      // props?.onMultipleFiltersUpdated?.(mergedFilters);
 
       const filters = [...props.filters, ...buildFilters];
       props?.onFiltersUpdated?.(filters);

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -399,17 +399,21 @@ export const QueryBarTopRow = React.memo(
     function onAddMultipleFiltersANDOR(selectedFilters: FilterGroup[], buildFilters: Filter[]) {
       const lastFilter: any = props.multipleFilters[props.multipleFilters.length - 1];
       const mappedFilters = mapAndFlattenFilters(buildFilters);
+      if (lastFilter !== undefined) lastFilter.relationship = 'AND';
       const mergedFilters = mappedFilters.map((filter, idx) => {
         let groupId = selectedFilters[idx].groupId;
-        // given 1 + last undefined  -> 1
-        // given 2 + last 1 -> 3
+        let id = selectedFilters[idx].id;
+        // groupId starts from 1; id starts from 0
 
-        if (lastFilter !== undefined) groupId = selectedFilters[idx].groupId + lastFilter.groupId;
+        if (lastFilter !== undefined) {
+          groupId += lastFilter.groupId;
+          id += lastFilter.id + 1;
+        }
 
         return {
           ...filter,
           groupId,
-          id: selectedFilters[idx].id,
+          id,
           relationship: selectedFilters[idx].relationship,
           subGroupId: selectedFilters[idx].subGroupId,
         };

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -38,6 +38,7 @@ import { NoDataPopover } from './no_data_popover';
 import { shallowEqual } from '../../utils/shallow_equal';
 import { SavedQuery } from '../..';
 import { AddFilterModal, FilterGroup } from './add_filter_modal';
+import { SavedQueryMeta } from '../saved_query_form';
 
 const SuperDatePicker = React.memo(
   EuiSuperDatePicker as any
@@ -86,6 +87,7 @@ export interface QueryBarTopRowProps {
   toggleAddFilterModal?: (value: boolean) => void;
   isAddFilterModalOpen?: boolean;
   addFilterMode?: string;
+  onNewFiltersSave: (savedQueryMeta: SavedQueryMeta) => void;
 }
 
 const SharingMetaFields = React.memo(function SharingMetaFields({
@@ -457,6 +459,7 @@ export const QueryBarTopRow = React.memo(
               timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
               savedQueryManagement={props.savedQueryManagement}
               initialAddFilterMode={props.addFilterMode}
+              saveFilters={props.onNewFiltersSave}
             />
           )}
         </EuiFlexItem>

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -21,7 +21,7 @@ interface Props {
   showFilterOption: boolean | undefined;
   showTimeFilterOption: boolean | undefined;
   filters?: Filter[];
-  onFilterBadgeSaved?: (alias: string) => void;
+  onFilterBadgeSave?: (alias: string) => void;
 }
 
 export interface SavedQueryMeta {
@@ -41,7 +41,7 @@ export function SaveQueryForm({
   showFilterOption = true,
   showTimeFilterOption = true,
   filters,
-  onFilterBadgeSaved,
+  onFilterBadgeSave,
 }: Props) {
   const [title, setTitle] = useState(savedQuery?.attributes.title ?? '');
   const [enabledSaveButton, setEnabledSaveButton] = useState(Boolean(savedQuery));
@@ -119,7 +119,7 @@ export function SaveQueryForm({
         shouldIncludeTimefilter,
         filters,
       });
-      if (onFilterBadgeSaved) onFilterBadgeSaved(title);
+      if (onFilterBadgeSave) onFilterBadgeSave(title);
     }
   }, [
     validate,
@@ -130,7 +130,7 @@ export function SaveQueryForm({
     shouldIncludeFilters,
     shouldIncludeTimefilter,
     filters,
-    onFilterBadgeSaved,
+    onFilterBadgeSave,
   ]);
 
   const onInputChange = useCallback((event) => {

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -21,6 +21,7 @@ interface Props {
   showFilterOption: boolean | undefined;
   showTimeFilterOption: boolean | undefined;
   filters?: Filter[];
+  onFilterBadgeSaved?: (alias: string) => void;
 }
 
 export interface SavedQueryMeta {
@@ -40,6 +41,7 @@ export function SaveQueryForm({
   showFilterOption = true,
   showTimeFilterOption = true,
   filters,
+  onFilterBadgeSaved,
 }: Props) {
   const [title, setTitle] = useState(savedQuery?.attributes.title ?? '');
   const [enabledSaveButton, setEnabledSaveButton] = useState(Boolean(savedQuery));
@@ -117,6 +119,7 @@ export function SaveQueryForm({
         shouldIncludeTimefilter,
         filters,
       });
+      if (onFilterBadgeSaved) onFilterBadgeSaved(title);
     }
   }, [
     validate,
@@ -127,6 +130,7 @@ export function SaveQueryForm({
     shouldIncludeFilters,
     shouldIncludeTimefilter,
     filters,
+    onFilterBadgeSaved,
   ]);
 
   const onInputChange = useCallback((event) => {

--- a/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
+++ b/src/plugins/data/public/ui/saved_query_form/save_query_form.tsx
@@ -9,6 +9,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { EuiButton, EuiForm, EuiFormRow, EuiFieldText, EuiSwitch, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { Filter } from '@kbn/es-query';
 import { sortBy, isEqual } from 'lodash';
 import { SavedQuery, SavedQueryService } from '../..';
 
@@ -19,6 +20,7 @@ interface Props {
   onClose: () => void;
   showFilterOption: boolean | undefined;
   showTimeFilterOption: boolean | undefined;
+  filters?: Filter[];
 }
 
 export interface SavedQueryMeta {
@@ -27,6 +29,7 @@ export interface SavedQueryMeta {
   description: string;
   shouldIncludeFilters: boolean;
   shouldIncludeTimefilter: boolean;
+  filters?: Filter[];
 }
 
 export function SaveQueryForm({
@@ -36,6 +39,7 @@ export function SaveQueryForm({
   onClose,
   showFilterOption = true,
   showTimeFilterOption = true,
+  filters,
 }: Props) {
   const [title, setTitle] = useState(savedQuery?.attributes.title ?? '');
   const [enabledSaveButton, setEnabledSaveButton] = useState(Boolean(savedQuery));
@@ -111,6 +115,7 @@ export function SaveQueryForm({
         description,
         shouldIncludeFilters,
         shouldIncludeTimefilter,
+        filters,
       });
     }
   }, [
@@ -121,6 +126,7 @@ export function SaveQueryForm({
     description,
     shouldIncludeFilters,
     shouldIncludeTimefilter,
+    filters,
   ]);
 
   const onInputChange = useCallback((event) => {

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -695,6 +695,8 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             removeSelectedSavedQuery={this.removeSelectedSavedQuery}
             onMultipleFiltersUpdated={this.onMultipleFiltersUpdated}
             multipleFilters={this.state.multipleFilters}
+            savedQueryService={this.savedQueryService}
+            onFilterSave={this.onSave}
           />
         </div>
       );

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -634,6 +634,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
           toggleAddFilterModal={this.toggleAddFilterModal}
           isAddFilterModalOpen={this.state.isAddFilterModalOpen}
           addFilterMode={this.state.addFilterMode}
+          onNewFiltersSave={(savedQueryMeta) => this.onSave(savedQueryMeta, true)}
         />
       );
     }

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -589,6 +589,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
           filters={this.props.filters!}
           onFiltersUpdated={this.props.onFiltersUpdated}
           onMultipleFiltersUpdated={this.onMultipleFiltersUpdated}
+          multipleFilters={this.state.multipleFilters}
           screenTitle={this.props.screenTitle}
           onSubmit={this.onQueryBarSubmit}
           indexPatterns={this.props.indexPatterns}

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -385,7 +385,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     // console.dir(filters);
   };
 
-  public onFilterBadgeSaved = (groupId: number, alias: string) => {
+  public onFilterBadgeSave = (groupId: number, alias: string) => {
     const multipleFilters = this.state.multipleFilters.map((filter: any) => {
       if (Number(filter.groupId) === groupId)
         return {
@@ -716,7 +716,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             multipleFilters={this.state.multipleFilters}
             savedQueryService={this.savedQueryService}
             onFilterSave={this.onSave}
-            onFilterBadgeSaved={this.onFilterBadgeSaved}
+            onFilterBadgeSave={this.onFilterBadgeSave}
           />
         </div>
       );

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -266,7 +266,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       query: this.state.query,
     };
 
-    if (savedQueryMeta.filters) {
+    if (savedQueryMeta.filters !== undefined) {
       savedQueryAttributes.filters = savedQueryMeta.filters;
     } else {
       savedQueryAttributes.filters = this.props.filters;

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -266,7 +266,9 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       query: this.state.query,
     };
 
-    if (savedQueryMeta.shouldIncludeFilters) {
+    if (savedQueryMeta.filters) {
+      savedQueryAttributes.filters = savedQueryMeta.filters;
+    } else {
       savedQueryAttributes.filters = this.props.filters;
     }
 
@@ -308,7 +310,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
         openFilterSetPopover: false,
       });
 
-      if (this.props.onSaved) {
+      if (!savedQueryMeta.filters && this.props.onSaved) {
         this.props.onSaved(response);
       }
     } catch (error) {

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -385,6 +385,21 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     // console.dir(filters);
   };
 
+  public onFilterBadgeSaved = (groupId: number, alias: string) => {
+    const multipleFilters = this.state.multipleFilters.map((filter: any) => {
+      if (Number(filter.groupId) === groupId)
+        return {
+          ...filter,
+          meta: {
+            ...filter.meta,
+            alias,
+          },
+        };
+      return filter;
+    });
+    this.setState({ multipleFilters });
+  };
+
   public applyTimeFilterOverrideModal = (selectedQueries?: SavedQuery[]) => {
     const queries = [...(selectedQueries || []), ...this.state.selectedSavedQueries];
     this.setState({ finalSelectedSavedQueries: queries });
@@ -701,6 +716,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             multipleFilters={this.state.multipleFilters}
             savedQueryService={this.savedQueryService}
             onFilterSave={this.onSave}
+            onFilterBadgeSaved={this.onFilterBadgeSaved}
           />
         </div>
       );


### PR DESCRIPTION
## Save filter expression and Create filter set with given label name from add filter modal

- Add Save as filter option for filter expression in dashboard search bar
![save-filter-badge](https://user-images.githubusercontent.com/59783836/151991164-b2e7fb9e-c83c-43e9-b12f-24bbc92a476b.gif)


- [Bug FIx](https://github.com/stratoula/kibana/pull/7/commits/4b73a8087d6f4388926af4e5a2c725b1d8dcc46d): old filters from filter bar disappear when add new ones
![fix-olds-desappear](https://user-images.githubusercontent.com/59783836/151833842-404af68e-ff42-4f8c-9af6-9bb254677c11.gif)

- When user gives label name in add filter modal it is automatically saved as filter set and will be added to filter bar with label name 
![add-labelled](https://user-images.githubusercontent.com/59783836/151835225-c0b0e80a-cb50-4c30-aadc-15c5b543f8fa.gif)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
