### PR TITLE
Id distribution issue

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -109,16 +109,30 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
 
     const multipleFilters = [...props.multipleFilters];
 
-    const newMultipleFilters = multipleFilters.filter(
-      (filter) => filter.groupId !== Number(groupId)
+    const indexOfCurFilter = multipleFilters.findIndex(
+      (f) => Number(f.groupId) === Number(groupId)
     );
+    multipleFilters.splice(indexOfCurFilter, 1, ...mergedFilters);
 
-    const filtersNew = newMultipleFilters.concat(mergedFilters);
+    // when user adds new filters in edit modal they should appear near of editing filter
+    let gId: number = 0;
+    let reserveGroupId: number;
+    const updatedMultipleFilters = multipleFilters.map((filter, idx) => {
+      if (filter.groupId !== reserveGroupId) {
+        reserveGroupId = filter.groupId;
+        gId++;
+      }
+      return {
+        ...filter,
+        groupId: gId,
+        id: idx,
+      };
+    });
 
     const filters = [...props.filters, ...buildFilters];
     props?.onFiltersUpdated?.(filters);
 
-    props?.onMultipleFiltersUpdated?.(filtersNew);
+    props?.onMultipleFiltersUpdated?.(updatedMultipleFilters);
 
     props.toggleEditFilterModal?.(false);
   }

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -187,7 +187,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
     labels.map((label) => {
       // we should have same groupIds on our labeled filters group
       gId = (groupedByAlias[label][0] as any).groupId;
-      groupedByAlias[label].forEach((filter) => ((filter as any).groupId = groupId));
+      groupedByAlias[label].forEach((filter) => ((filter as any).groupId = gId));
       const labelBadge = (
         <FilterExpressionItem
           groupId={gId}

--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -245,6 +245,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
             timeRangeForSuggestionsOverride={props.timeRangeForSuggestionsOverride}
             initialAddFilterMode={undefined}
             saveFilters={props.onFilterSave}
+            savedQueryService={props.savedQueryService}
           />
         )}
       </EuiFlexItem>

--- a/src/plugins/data/public/ui/query_string_input/_query_bar.scss
+++ b/src/plugins/data/public/ui/query_string_input/_query_bar.scss
@@ -28,6 +28,23 @@
   }
 }
 
+.kbnQueryBar__dataViewInput {
+  & .euiFormRow__labelWrapper {
+    width: fit-content;
+    color: $euiTitleColor;
+    background-color: $euiFormInputGroupLabelBackground;
+    margin-right: 0;
+    padding: 0 7px;
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+  }
+
+  & .euiComboBox__inputWrap {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+}
+
 .kbnQueryBar__filterModalWrapper {
   @media only screen and (min-width: map-get($euiBreakpoints, 'm')) {
     & {
@@ -89,6 +106,7 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+
   &.kbnQueryBar__textarea--hasAppend {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
@@ -113,6 +131,7 @@
   }
 
   @include euiFormControlWithIcon($isIconOptional: true);
+
   ~ .euiFormControlLayoutIcons {
     // By default form control layout icon is vertically centered, but our textarea
     // can expand to be multi-line, so we position it with padding that matches

--- a/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
@@ -118,8 +118,19 @@ export function AddFilterModal({
       field: undefined,
       operator: undefined,
       value: undefined,
-      groupId: multipleFilters?.length ? multipleFilters?.length + 1 : 1,
-      id: multipleFilters?.length ? multipleFilters?.length : 0,
+      // find the max groupId and id and start from + 1
+      groupId: multipleFilters?.length
+        ? Math.max.apply(
+            Math,
+            multipleFilters.map((f) => f.groupId)
+          ) + 1
+        : 1,
+      id: multipleFilters?.length
+        ? Math.max.apply(
+            Math,
+            multipleFilters.map((f) => f.id)
+          ) + 1
+        : 0,
       subGroupId: 1,
       relationship: undefined,
     },
@@ -504,7 +515,7 @@ export function AddFilterModal({
                                     const subGroupId =
                                       filtersOnGroup.length > 2
                                         ? localfilter?.subGroupId ?? 0
-                                        : localfilter?.subGroupId ?? 0;
+                                        : (localfilter?.subGroupId ?? 0) + 1;
                                     const updatedLocalFilter = {
                                       ...localfilter,
                                       relationship: 'AND',
@@ -524,10 +535,8 @@ export function AddFilterModal({
                                         relationship: undefined,
                                         groupId:
                                           filtersOnGroup.length > 1
-                                            ? groupsCount
-                                            : Number(multipleFilters?.length) +
-                                              localFilters.length +
-                                              1,
+                                            ? localFilters[localFilters.length - 1].groupId
+                                            : localFilters[localFilters.length - 1].groupId + 1,
                                         subGroupId,
                                         id: Number(multipleFilters?.length) + localFilters.length,
                                       },

--- a/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
@@ -202,8 +202,9 @@ export function AddFilterModal({
       <EuiFormRow
         fullWidth
         display="columnCompressed"
-        label={i18n.translate('data.filter.filterEditor.indexPatternSelectLabel', {
-          defaultMessage: 'Index pattern',
+        className="kbnQueryBar__dataViewInput"
+        label={i18n.translate('data.filter.filterEditor.dataViewSelectLabel', {
+          defaultMessage: 'Data view',
         })}
       >
         <GenericComboBox

--- a/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/add_filter_modal.tsx
@@ -30,6 +30,7 @@ import {
   EuiText,
   EuiIcon,
   EuiFieldText,
+  EuiBadge,
 } from '@elastic/eui';
 import { XJsonLang } from '@kbn/monaco';
 import { i18n } from '@kbn/i18n';
@@ -139,7 +140,24 @@ export function AddFilterModal({
   const onIndexPatternChange = ([selectedPattern]: IIndexPattern[]) => {
     setSelectedIndexPattern(selectedPattern);
     setLocalFilters([
-      { field: undefined, operator: undefined, value: undefined, groupId: 1, id: 0, subGroupId: 1 },
+      {
+        field: undefined,
+        operator: undefined,
+        value: undefined,
+        groupId: multipleFilters?.length
+          ? Math.max.apply(
+              Math,
+              multipleFilters.map((f) => f.groupId)
+            ) + 1
+          : 1,
+        id: multipleFilters?.length
+          ? Math.max.apply(
+              Math,
+              multipleFilters.map((f) => f.id)
+            ) + 1
+          : 0,
+        subGroupId: 1,
+      },
     ]);
     setGroupsCount(1);
   };

--- a/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
@@ -266,11 +266,11 @@ export function EditFilterModal({
           placeholder={
             selectedField
               ? i18n.translate('data.filter.filterEditor.operatorSelectPlaceholderSelect', {
-                defaultMessage: 'Operator',
-              })
+                  defaultMessage: 'Operator',
+                })
               : i18n.translate('data.filter.filterEditor.operatorSelectPlaceholderWaiting', {
-                defaultMessage: 'Waiting',
-              })
+                  defaultMessage: 'Waiting',
+                })
           }
           options={operators}
           selectedOptions={selectedOperator ? [selectedOperator] : []}
@@ -461,8 +461,8 @@ export function EditFilterModal({
               subGroup.length > 1 && groupsCount > 1
                 ? 'kbnQueryBar__filterModalSubGroups'
                 : groupsCount === 1 && subGroup.length > 1
-                  ? 'kbnQueryBar__filterModalGroups'
-                  : '';
+                ? 'kbnQueryBar__filterModalGroups'
+                : '';
             return (
               <>
                 <div className={classNames(classes)}>
@@ -484,23 +484,28 @@ export function EditFilterModal({
                             </EuiFlexGroup>
                           </EuiFlexItem>
                           <EuiFlexItem grow={false}>
-
                             <EuiFlexGroup responsive={false} justifyContent="center">
                               {subGroup.length < 2 && (
                                 <EuiFlexItem grow={false}>
                                   <EuiButtonIcon
                                     onClick={() => {
-                                      const updatedLocalFilter = { ...localfilter, relationship: 'OR' };
+                                      const updatedLocalFilter = {
+                                        ...localfilter,
+                                        relationship: 'OR',
+                                      };
                                       const idx = localFilters.findIndex(
-                                        (f) => f.id === localfilter.id && f.groupId === Number(groupId)
+                                        (f) =>
+                                          f.id === localfilter.id && f.groupId === Number(groupId)
                                       );
                                       const subGroupId = (localfilter?.subGroupId ?? 0) + 1;
                                       if (subGroup.length < 2) {
                                         localFilters[idx] = updatedLocalFilter;
                                       }
-                                      const countOfFilterBeforeFilterEdit = multipleFilters.filter(
-                                        (f) => f.groupId === Number(groupId)
-                                      );
+                                      const newId =
+                                        Math.max(
+                                          multipleFilters?.length - 1,
+                                          localFilters[localFilters.length - 1].id
+                                        ) + 1;
                                       setLocalFilters([
                                         ...localFilters,
                                         {
@@ -509,7 +514,7 @@ export function EditFilterModal({
                                           value: undefined,
                                           relationship: undefined,
                                           groupId: localfilter.groupId,
-                                          id: Number(multipleFilters.length) - countOfFilterBeforeFilterEdit.length + localFilters.length,
+                                          id: newId,
                                           subGroupId,
                                         },
                                       ]);
@@ -537,12 +542,24 @@ export function EditFilterModal({
                                       subGroupId: filtersOnGroup.length > 1 ? subGroupId : 1,
                                     };
                                     const idx = localFilters.findIndex(
-                                      (f) => f.id === localfilter.id && f.groupId === Number(groupId)
+                                      (f) =>
+                                        f.id === localfilter.id && f.groupId === Number(groupId)
                                     );
                                     localFilters[idx] = updatedLocalFilter;
-                                    const countOfFilterBeforeFilterEdit = multipleFilters.filter(
-                                      (f) => f.groupId === Number(groupId)
+                                    const maxExistingGroupIdValue: number = Math.max.apply(
+                                      Math,
+                                      multipleFilters?.map((f) => f.groupId)
                                     );
+                                    const newGroupId =
+                                      Math.max(
+                                        maxExistingGroupIdValue,
+                                        localFilters[localFilters.length - 1].groupId
+                                      ) + 1;
+                                    const newId =
+                                      Math.max(
+                                        multipleFilters?.length - 1,
+                                        localFilters[localFilters.length - 1].id
+                                      ) + 1;
                                     setLocalFilters([
                                       ...localFilters,
                                       {
@@ -550,9 +567,12 @@ export function EditFilterModal({
                                         operator: undefined,
                                         value: undefined,
                                         relationship: undefined,
-                                        groupId: filtersOnGroup.length > 1 ? groupsCount : (Number(multipleFilters?.length) - countOfFilterBeforeFilterEdit.length + localFilters.length + 1),
+                                        groupId:
+                                          filtersOnGroup.length > 1
+                                            ? localFilters[localFilters.length - 1].groupId
+                                            : newGroupId,
+                                        id: newId,
                                         subGroupId,
-                                        id: Number(multipleFilters.length) - countOfFilterBeforeFilterEdit.length + localFilters.length,
                                       },
                                     ]);
                                     if (filtersOnGroup.length <= 1) {

--- a/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
@@ -214,8 +214,9 @@ export function EditFilterModal({
       <EuiFormRow
         fullWidth
         display="columnCompressed"
-        label={i18n.translate('data.filter.filterEditor.indexPatternSelectLabel', {
-          defaultMessage: 'Index pattern',
+        className="kbnQueryBar__dataViewInput"
+        label={i18n.translate('data.filter.filterEditor.dataViewSelectLabel', {
+          defaultMessage: 'Data view',
         })}
       >
         <GenericComboBox

--- a/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
@@ -152,7 +152,24 @@ export function EditFilterModal({
   const onIndexPatternChange = ([selectedPattern]: IIndexPattern[]) => {
     setSelectedIndexPattern(selectedPattern);
     setLocalFilters([
-      { field: undefined, operator: undefined, value: undefined, groupId: 1, id: 0, subGroupId: 1 },
+      {
+        field: undefined,
+        operator: undefined,
+        value: undefined,
+        groupId: multipleFilters?.length
+          ? Math.max.apply(
+              Math,
+              multipleFilters.map((f) => f.groupId)
+            ) + 1
+          : 1,
+        id: multipleFilters?.length
+          ? Math.max.apply(
+              Math,
+              multipleFilters.map((f) => f.id)
+            ) + 1
+          : 0,
+        subGroupId: 1,
+      },
     ]);
     setGroupsCount(1);
   };

--- a/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
+++ b/src/plugins/data/public/ui/query_string_input/edit_filter_modal.tsx
@@ -413,7 +413,7 @@ export function EditFilterModal({
     }
     const alias = customLabel || null;
     // validation for existence of saved filter with given alias
-    if (alias && isLabelDuplicated()) {
+    if (alias && !filter.meta.alias && isLabelDuplicated()) {
       setSubmitDisabled(true);
       return;
     }

--- a/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/data/public/ui/query_string_input/query_bar_top_row.tsx
@@ -25,7 +25,14 @@ import {
   OnRefreshProps,
   EuiButtonIcon,
 } from '@elastic/eui';
-import { IDataPluginServices, IIndexPattern, TimeRange, TimeHistoryContract, Query } from '../..';
+import {
+  IDataPluginServices,
+  IIndexPattern,
+  TimeRange,
+  TimeHistoryContract,
+  Query,
+  SavedQueryService,
+} from '../..';
 import { mapAndFlattenFilters } from '../../query/filter_manager/lib/map_and_flatten_filters';
 import { useKibana, withKibana } from '../../../../kibana_react/public';
 import QueryStringInputUI from './query_string_input';
@@ -85,6 +92,7 @@ export interface QueryBarTopRowProps {
   isAddFilterModalOpen?: boolean;
   addFilterMode?: string;
   onNewFiltersSave: (savedQueryMeta: SavedQueryMeta) => void;
+  savedQueryService: SavedQueryService;
 }
 
 const SharingMetaFields = React.memo(function SharingMetaFields({
@@ -400,8 +408,8 @@ export const QueryBarTopRow = React.memo(
         // groupId starts from 1; id starts from 0
 
         if (lastFilter !== undefined) {
-        //   groupId += lastFilter.groupId;
-        //   id += lastFilter.id + 1;
+          //   groupId += lastFilter.groupId;
+          //   id += lastFilter.id + 1;
         }
 
         return {
@@ -459,6 +467,7 @@ export const QueryBarTopRow = React.memo(
               savedQueryManagement={props.savedQueryManagement}
               initialAddFilterMode={props.addFilterMode}
               saveFilters={props.onNewFiltersSave}
+              savedQueryService={props.savedQueryService}
             />
           )}
         </EuiFlexItem>

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -651,6 +651,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
           isAddFilterModalOpen={this.state.isAddFilterModalOpen}
           addFilterMode={this.state.addFilterMode}
           onNewFiltersSave={(savedQueryMeta) => this.onSave(savedQueryMeta, true)}
+          savedQueryService={this.savedQueryService}
         />
       );
     }

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -294,7 +294,8 @@ class SearchBarUI extends Component<SearchBarProps, State> {
 
     try {
       let response;
-      if (this.props.savedQuery && !saveAsNew) {
+      // if (this.props.savedQuery && !saveAsNew) {
+      if (!saveAsNew) {
         response = await this.savedQueryService.updateQuery(
           savedQueryMeta.id!,
           savedQueryAttributes

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -146,7 +146,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       nextQuery = {
         query: nextProps.query.query,
         language: nextProps.query.language,
-        isFromSavedQuery: nextProps.query.isFromSavedQuery ?? false,
+        // isFromSavedQuery: nextProps.query.isFromSavedQuery ?? false,
       };
     } else if (
       nextProps.query &&
@@ -260,13 +260,17 @@ class SearchBarUI extends Component<SearchBarProps, State> {
     );
   }
 
-  public onSave = async (savedQueryMeta: SavedQueryMeta, saveAsNew = false) => {
-    if (!this.state.query) return;
+  public onSave = async (
+    savedQueryMeta: SavedQueryMeta,
+    saveAsNew = false,
+    query = this.state.query
+  ) => {
+    if (!query) return;
 
     const savedQueryAttributes: SavedQueryAttributes = {
       title: savedQueryMeta.title,
       description: savedQueryMeta.description,
-      query: this.state.query,
+      query,
     };
 
     if (savedQueryMeta.filters !== undefined) {
@@ -319,7 +323,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       }
     } catch (error) {
       this.services.notifications.toasts.addDanger(
-        `An error occured while saving your query: ${error.message}`
+        `An error occured while saving your query: ${error}`
       );
       throw error;
     }
@@ -651,7 +655,12 @@ class SearchBarUI extends Component<SearchBarProps, State> {
           toggleAddFilterModal={this.toggleAddFilterModal}
           isAddFilterModalOpen={this.state.isAddFilterModalOpen}
           addFilterMode={this.state.addFilterMode}
-          onNewFiltersSave={(savedQueryMeta) => this.onSave(savedQueryMeta, true)}
+          onNewFiltersSave={(savedQueryMeta) =>
+            this.onSave(savedQueryMeta, true, {
+              language: this.state.query!.language,
+              query: '',
+            })
+          }
           savedQueryService={this.savedQueryService}
         />
       );
@@ -721,7 +730,13 @@ class SearchBarUI extends Component<SearchBarProps, State> {
             isEditFilterModalOpen={this.state.isEditFilterModalOpen}
             editFilterMode={this.state.editFilterMode}
             savedQueryService={this.savedQueryService}
-            onFilterSave={this.onSave}
+            onFilterSave={(savedQueryMeta: SavedQueryMeta, saveAsNew = false) => {
+              console.log(this.state.query);
+              return this.onSave(savedQueryMeta, saveAsNew, {
+                language: this.state.query!.language,
+                query: '',
+              });
+            }}
             onFilterBadgeSave={this.onFilterBadgeSave}
           />
         </div>

--- a/src/plugins/data/public/ui/search_bar/search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/search_bar.tsx
@@ -323,7 +323,7 @@ class SearchBarUI extends Component<SearchBarProps, State> {
       }
     } catch (error) {
       this.services.notifications.toasts.addDanger(
-        `An error occured while saving your query: ${error}`
+        `An error occured while saving your query: ${error.message}`
       );
       throw error;
     }


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

### Fix the id & groupId distribution for both modals(add, edit) on initialization

| before      |
| ----------- |
| ![distribution-before](https://user-images.githubusercontent.com/59783836/153808031-c4a3deab-686b-4c0f-abee-564c50870dac.gif) | 
|  now  | 
| ![distribution-now](https://user-images.githubusercontent.com/59783836/153808053-5a4d107e-a7dc-41ab-954c-e814c49e15b5.gif) |

### Fix the ordering of filter badges on adding new filters(as new groups) on the edit modal

| before      |
| ----------- |
| ![edit-order-before](https://user-images.githubusercontent.com/59783836/153808160-4476e10a-18db-4c2b-b499-5c2f5f102748.gif) | 
|  now  | 
| ![edit-order-now](https://user-images.githubusercontent.com/59783836/153808176-47af7e2d-8371-4706-adb6-9e74cda6e8c7.gif) |

### Refactor the data view changing form, make it as in design in add & edit modals

| before      |  now |
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/59783836/153803702-e6e49418-67e7-4560-aa1e-bdef324f358a.png) | ![image](https://user-images.githubusercontent.com/59783836/153803675-e9894a43-54ad-406f-8316-f19e2ff56aeb.png) |

### Implement validation for submitting filters with label for existence
![validation](https://user-images.githubusercontent.com/59783836/153906715-c43d7381-0384-4715-86b7-018d99bc04f0.gif)

### Update alias if filters already have it
![update-existing](https://user-images.githubusercontent.com/59783836/154021561-6cee0d01-3c3f-4e28-a6f5-8750f01ef7e0.gif)

### Fix saving the filter badges without queries from query bar

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
