### PR TITLE
Show filter's tooltip

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_expression_item.tsx
@@ -404,7 +404,6 @@ export const FilterExpressionItem: FC<Props> = ({
     }
     for (const filter of subGroupedFilters) {
       const label = getValueLabel(filter);
-
       const prefixText = filter.meta.negate
         ? ` ${i18n.translate('data.filter.filterBar.negatedFilterPrefix', {
           defaultMessage: 'NOT ',
@@ -421,9 +420,7 @@ export const FilterExpressionItem: FC<Props> = ({
       const filterContent = getFilterContent(filter, label, prefix, relationship);
       filterExpression.push(filterContent);
 
-      const text = label.title;
-      filterText += `${filter?.meta?.key}: ${text} ${groupedFilters.length > 1 ? filter.relationship || '' : ''
-        } `;
+      filterText += `${filter?.meta?.key}: ${filter?.meta?.params?.query} ${relationship} `;
     }
     if (needsParenthesis) {
       filterExpression.push(<EuiTextColor color="rgb(0, 113, 194)">)</EuiTextColor>);


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Show filter's tooltip
Before

https://user-images.githubusercontent.com/34135714/156121713-1247823a-74f4-42c9-91af-ac2c067fcfb6.mov

After 

https://user-images.githubusercontent.com/34135714/156121814-90fddac6-672f-4570-ac0c-bab44ff0b094.mov



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


