### PR TITLE
Fix issue adding saved filters one by one

### DIFF
--- a/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
+++ b/src/plugins/data/public/ui/filter_bar/filter_bar.tsx
@@ -81,7 +81,7 @@ const FilterBarUI = React.memo(function FilterBarUI(props: Props) {
   }, []);
 
   useEffect(() => {
-    const savedFiltersGroupIds: number[] = [];
+    const savedFiltersGroupIds: number[] = [...selectedSavedFiltersGroupIds];
     let groupId = getInitForField(props.multipleFilters, 'groupId', 1);
     let id = getInitForField(props.multipleFilters, 'id', 0);
 


### PR DESCRIPTION
## Fix issue adding saved filters one by one

- when you add saved filters one by one and when editing some of them open the edit modal with quick_form, but we want it open just query builder;

