### PR TITLE
Text-based Discover Lens cleanup

### DIFF
--- a/src/plugins/discover/public/__mocks__/services.ts
+++ b/src/plugins/discover/public/__mocks__/services.ts
@@ -57,6 +57,14 @@ export function createDiscoverServicesMock(): DiscoverServices {
     },
   }));
   dataPlugin.dataViews = createDiscoverDataViewsMock();
+  expressionsPlugin.run = jest.fn(() =>
+    of({
+      partial: false,
+      result: {
+        rows: [],
+      },
+    })
+  ) as unknown as typeof expressionsPlugin.run;
 
   return {
     core: coreMock.createStart(),

--- a/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.tsx
@@ -46,6 +46,7 @@ export const DiscoverHistogramLayout = ({
     inspectorAdapters,
     savedSearchFetch$: stateContainer.dataState.fetch$,
     searchSessionId,
+    isPlainRecord,
     ...commonProps,
   });
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_histogram_layout.tsx
@@ -46,7 +46,6 @@ export const DiscoverHistogramLayout = ({
     inspectorAdapters,
     savedSearchFetch$: stateContainer.dataState.fetch$,
     searchSessionId,
-    isPlainRecord,
     ...commonProps,
   });
 

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.test.tsx
@@ -163,20 +163,6 @@ describe('Discover component', () => {
     ).not.toBeNull();
   }, 10000);
 
-  test('sql query displays no chart toggle', async () => {
-    const container = document.createElement('div');
-    await mountComponent(
-      dataViewWithTimefieldMock,
-      false,
-      { attachTo: container },
-      { sql: 'SELECT * FROM test' },
-      true
-    );
-    expect(
-      container.querySelector('[data-test-subj="unifiedHistogramChartOptionsToggle"]')
-    ).toBeNull();
-  });
-
   test('the saved search title h1 gains focus on navigate', async () => {
     const container = document.createElement('div');
     document.body.appendChild(container);

--- a/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_main_content.tsx
@@ -72,12 +72,12 @@ export const DiscoverMainContent = ({
       gutterSize="none"
       responsive={false}
     >
-      {!isPlainRecord && (
-        <EuiFlexItem grow={false}>
-          <EuiHorizontalRule margin="none" />
+      <EuiFlexItem grow={false}>
+        <EuiHorizontalRule margin="none" />
+        {!isPlainRecord && (
           <DocumentViewModeToggle viewMode={viewMode} setDiscoverViewMode={setDiscoverViewMode} />
-        </EuiFlexItem>
-      )}
+        )}
+      </EuiFlexItem>
       {dataState.error && (
         <ErrorCallout
           title={i18n.translate('discover.documentsErrorTitle', {

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.test.tsx
@@ -211,7 +211,7 @@ describe('useDiscoverHistogram', () => {
       act(() => {
         hook.result.current.setUnifiedHistogramApi(api);
       });
-      expect(api.state$.subscribe).toHaveBeenCalledTimes(2);
+      expect(api.state$.subscribe).toHaveBeenCalledTimes(4);
     });
 
     it('should sync Unified Histogram state with the state container', async () => {
@@ -225,6 +225,7 @@ describe('useDiscoverHistogram', () => {
         breakdownField: 'test',
         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
         totalHitsResult: undefined,
+        dataView: dataViewWithTimefieldMock,
       } as unknown as UnifiedHistogramState;
       const api = createMockUnifiedHistogramApi({ initialized: true });
       api.state$ = new BehaviorSubject({ ...state, lensRequestAdapter });
@@ -249,6 +250,7 @@ describe('useDiscoverHistogram', () => {
         breakdownField: containerState.breakdownField,
         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
         totalHitsResult: undefined,
+        dataView: dataViewWithTimefieldMock,
       } as unknown as UnifiedHistogramState;
       const api = createMockUnifiedHistogramApi({ initialized: true });
       api.state$ = new BehaviorSubject(state);
@@ -311,6 +313,7 @@ describe('useDiscoverHistogram', () => {
         breakdownField: containerState.breakdownField,
         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
         totalHitsResult: undefined,
+        dataView: dataViewWithTimefieldMock,
       } as unknown as UnifiedHistogramState;
       const api = createMockUnifiedHistogramApi({ initialized: true });
       let params: Partial<UnifiedHistogramState> = {};
@@ -373,6 +376,7 @@ describe('useDiscoverHistogram', () => {
         breakdownField: containerState.breakdownField,
         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
         totalHitsResult: undefined,
+        dataView: dataViewWithTimefieldMock,
       } as unknown as UnifiedHistogramState;
       const api = createMockUnifiedHistogramApi({ initialized: true });
       api.state$ = new BehaviorSubject({
@@ -388,52 +392,6 @@ describe('useDiscoverHistogram', () => {
         result: 100,
       });
       expect(mockCheckHitCount).toHaveBeenCalledWith(main$, 100);
-    });
-
-    it('should fetch total hits for text based', async () => {
-      mockQueryState = {
-        query: { sql: 'select * from index' },
-        filters: [],
-        time: {
-          from: 'now-15m',
-          to: 'now',
-        },
-      };
-
-      mockData.query.getState = () => mockQueryState;
-      const documents$ = new BehaviorSubject({
-        fetchStatus: FetchStatus.COMPLETE,
-        result: [{ raw: {}, flattened: {}, id: '1' }],
-      }) as unknown as DataDocuments$;
-      const main$ = new BehaviorSubject({
-        fetchStatus: FetchStatus.COMPLETE,
-        recordRawType: RecordRawType.DOCUMENT,
-        foundDocuments: true,
-      }) as DataMain$;
-      const stateContainer = getStateContainer();
-      const { hook } = await renderUseDiscoverHistogram({
-        stateContainer,
-        documents$,
-        main$,
-        isPlainRecord: true,
-      });
-      const api = createMockUnifiedHistogramApi({ initialized: true });
-      let params: Partial<UnifiedHistogramState> = {};
-      api.setTotalHits = jest.fn((p) => {
-        params = { ...params, ...p };
-      });
-      act(() => {
-        hook.result.current.setUnifiedHistogramApi(api);
-      });
-      expect(api.setTotalHits).toHaveBeenCalledWith({
-        totalHitsResult: 1,
-        totalHitsStatus: FetchStatus.COMPLETE,
-      });
-      expect(documents$.value).toEqual({
-        fetchStatus: FetchStatus.COMPLETE,
-        result: [{ raw: {}, flattened: {}, id: '1' }],
-      });
-      expect(mockCheckHitCount).not.toHaveBeenCalled();
     });
 
     it('should not update total hits when the total hits state changes to an error', async () => {
@@ -464,6 +422,7 @@ describe('useDiscoverHistogram', () => {
         breakdownField: containerState.breakdownField,
         totalHitsStatus: UnifiedHistogramFetchStatus.loading,
         totalHitsResult: undefined,
+        dataView: dataViewWithTimefieldMock,
       } as unknown as UnifiedHistogramState;
       const api = createMockUnifiedHistogramApi({ initialized: true });
       api.state$ = new BehaviorSubject({

--- a/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
+++ b/src/plugins/discover/public/application/main/components/layout/use_discover_histogram.ts
@@ -218,7 +218,7 @@ export const useDiscoverHistogram = ({
   }, [breakdownField, unifiedHistogram]);
 
   const columns = useAppStateSelector((state) => state.columns);
-  const documentState = useDataState(savedSearchData$.documents$);
+
 
   useEffect(() => {
     const currentQueryIsTextBased = query && isOfAggregateQueryType(query);
@@ -236,15 +236,6 @@ export const useDiscoverHistogram = ({
       prev.current.columns = columns;
     }
   }, [columns, query, unifiedHistogram]);
-
-  useEffect(() => {
-    if (isPlainRecord) {
-      unifiedHistogram?.setTotalHits({
-        totalHitsResult: documentState.result?.length,
-        totalHitsStatus: documentState.fetchStatus.toString() as UnifiedHistogramFetchStatus,
-      });
-    }
-  }, [documentState.fetchStatus, documentState.result, isPlainRecord, unifiedHistogram]);
 
   /**
    * Total hits

--- a/src/plugins/unified_histogram/kibana.jsonc
+++ b/src/plugins/unified_histogram/kibana.jsonc
@@ -7,11 +7,6 @@
     "id": "unifiedHistogram",
     "server": false,
     "browser": true,
-    "requiredBundles": [
-      "data",
-      "dataViews",
-      "embeddable",
-      "inspector"
-    ]
+    "requiredBundles": ["data", "dataViews", "embeddable", "inspector", "expressions"]
   }
 }

--- a/src/plugins/unified_histogram/public/__mocks__/services.ts
+++ b/src/plugins/unified_histogram/public/__mocks__/services.ts
@@ -8,6 +8,7 @@
 
 import { EUI_CHARTS_THEME_LIGHT } from '@elastic/eui/dist/eui_charts_theme';
 import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { expressionsPluginMock } from '@kbn/expressions-plugin/public/mocks';
 import { fieldFormatsMock } from '@kbn/field-formats-plugin/common/mocks';
 import type { UnifiedHistogramServices } from '../types';
 import { allSuggestionsMock } from './suggestions';
@@ -44,4 +45,5 @@ export const unifiedHistogramServicesMock = {
     remove: jest.fn(),
     clear: jest.fn(),
   },
+  expressions: expressionsPluginMock.createStartContract(),
 } as unknown as UnifiedHistogramServices;

--- a/src/plugins/unified_histogram/public/chart/chart.tsx
+++ b/src/plugins/unified_histogram/public/chart/chart.tsx
@@ -161,6 +161,7 @@ export function Chart({
     filters,
     query,
     relativeTimeRange,
+    currentSuggestion,
     disableAutoFetching,
     input$,
     beforeRefetch: updateTimeRange,

--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -105,7 +105,10 @@ export function Histogram({
         return;
       }
 
-      const totalHits = adapters?.tables?.tables?.unifiedHistogram?.meta?.statistics?.totalCount;
+      const adapterTables = adapters?.tables?.tables;
+      const totalHits = isPlainRecord
+        ? Object.values(adapterTables ?? {})?.[0]?.rows?.length
+        : adapterTables?.unifiedHistogram?.meta?.statistics?.totalCount;
 
       onTotalHitsChange?.(
         isLoading ? UnifiedHistogramFetchStatus.loading : UnifiedHistogramFetchStatus.complete,

--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -137,7 +137,6 @@ export function Histogram({
     refetch$,
     attributes,
     onLoad,
-    isPlainRecord,
   });
 
   const { euiTheme } = useEuiTheme();

--- a/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.test.ts
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.test.ts
@@ -80,7 +80,6 @@ describe('useLensProps', () => {
         refetch$,
         attributes,
         onLoad,
-        isPlainRecord: true,
       });
     });
     expect(lensProps.result.current).toEqual(

--- a/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.ts
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_lens_props.ts
@@ -21,14 +21,12 @@ export const useLensProps = ({
   refetch$,
   attributes,
   onLoad,
-  isPlainRecord,
 }: {
   request?: UnifiedHistogramRequestContext;
   getTimeRange: () => TimeRange;
   refetch$: Observable<UnifiedHistogramInputMessage>;
   attributes: TypedLensByValueInput['attributes'];
   onLoad: (isLoading: boolean, adapters: Partial<DefaultInspectorAdapters> | undefined) => void;
-  isPlainRecord?: boolean;
 }) => {
   const buildLensProps = useCallback(
     () =>
@@ -49,14 +47,6 @@ export const useLensProps = ({
     return () => subscription.unsubscribe();
   }, [refetch$, updateLensProps]);
 
-  if (Boolean(isPlainRecord)) {
-    return getLensProps({
-      searchSessionId: request?.searchSessionId,
-      getTimeRange,
-      attributes,
-      onLoad,
-    });
-  }
   return lensProps;
 };
 

--- a/src/plugins/unified_histogram/public/chart/hooks/use_refetch.ts
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_refetch.ts
@@ -8,6 +8,7 @@
 
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
+import type { Suggestion } from '@kbn/lens-plugin/public';
 import { cloneDeep, isEqual } from 'lodash';
 import { useEffect, useMemo, useRef } from 'react';
 import { filter, share, tap } from 'rxjs';
@@ -29,6 +30,7 @@ export const useRefetch = ({
   filters,
   query,
   relativeTimeRange,
+  currentSuggestion,
   disableAutoFetching,
   input$,
   beforeRefetch,
@@ -42,6 +44,7 @@ export const useRefetch = ({
   filters: Filter[];
   query: Query | AggregateQuery;
   relativeTimeRange: TimeRange;
+  currentSuggestion?: Suggestion;
   disableAutoFetching?: boolean;
   input$: UnifiedHistogramInput$;
   beforeRefetch: () => void;
@@ -67,6 +70,7 @@ export const useRefetch = ({
       filters,
       query,
       relativeTimeRange,
+      currentSuggestion,
     });
 
     if (!isEqual(refetchDeps.current, newRefetchDeps)) {
@@ -80,6 +84,7 @@ export const useRefetch = ({
     breakdown,
     chart,
     chartVisible,
+    currentSuggestion,
     dataView,
     disableAutoFetching,
     filters,
@@ -111,6 +116,7 @@ const getRefetchDeps = ({
   filters,
   query,
   relativeTimeRange,
+  currentSuggestion,
 }: {
   dataView: DataView;
   request: UnifiedHistogramRequestContext | undefined;
@@ -121,6 +127,7 @@ const getRefetchDeps = ({
   filters: Filter[];
   query: Query | AggregateQuery;
   relativeTimeRange: TimeRange;
+  currentSuggestion?: Suggestion;
 }) =>
   cloneDeep([
     dataView.id,
@@ -133,4 +140,5 @@ const getRefetchDeps = ({
     filters,
     query,
     relativeTimeRange,
+    currentSuggestion,
   ]);

--- a/src/plugins/unified_histogram/public/chart/hooks/use_refetch.ts
+++ b/src/plugins/unified_histogram/public/chart/hooks/use_refetch.ts
@@ -140,5 +140,5 @@ const getRefetchDeps = ({
     filters,
     query,
     relativeTimeRange,
-    currentSuggestion,
+    currentSuggestion?.visualizationId,
   ]);

--- a/src/plugins/unified_histogram/public/container/container.test.tsx
+++ b/src/plugins/unified_histogram/public/container/container.test.tsx
@@ -32,7 +32,6 @@ describe('UnifiedHistogramContainer', () => {
     totalHitsStatus: UnifiedHistogramFetchStatus.uninitialized,
     totalHitsResult: undefined,
     columns: [],
-    allSuggestions: undefined,
     currentSuggestion: undefined,
   };
 
@@ -64,7 +63,7 @@ describe('UnifiedHistogramContainer', () => {
     const component = mountWithIntl(
       <UnifiedHistogramContainer ref={setApi} resizeRef={{ current: null }} />
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
     expect(component.update().isEmptyRender()).toBe(false);
   });
 
@@ -83,6 +82,7 @@ describe('UnifiedHistogramContainer', () => {
         });
       }
     });
+    await act(() => new Promise((resolve) => setTimeout(resolve, 0)));
     expect(api?.initialized).toBe(true);
   });
 });

--- a/src/plugins/unified_histogram/public/container/container.tsx
+++ b/src/plugins/unified_histogram/public/container/container.tsx
@@ -20,6 +20,8 @@ import {
 import { useStateProps } from './hooks/use_state_props';
 import { useStateSelector } from './utils/use_state_selector';
 import {
+  columnsSelector,
+  currentSuggestionSelector,
   dataViewSelector,
   filtersSelector,
   querySelector,
@@ -155,6 +157,8 @@ export const UnifiedHistogramContainer = forwardRef<
   const query = useStateSelector(stateService?.state$, querySelector);
   const filters = useStateSelector(stateService?.state$, filtersSelector);
   const timeRange = useStateSelector(stateService?.state$, timeRangeSelector);
+  const columns = useStateSelector(stateService?.state$, columnsSelector);
+  const currentSuggestion = useStateSelector(stateService?.state$, currentSuggestionSelector);
   const topPanelHeight = useStateSelector(stateService?.state$, topPanelHeightSelector);
 
   // Don't render anything until the container is initialized
@@ -171,6 +175,8 @@ export const UnifiedHistogramContainer = forwardRef<
       query={query}
       filters={filters}
       timeRange={timeRange}
+      columns={columns}
+      currentSuggestion={currentSuggestion}
       topPanelHeight={topPanelHeight}
       input$={input$}
       lensSuggestionsApi={lensSuggestionsApi}

--- a/src/plugins/unified_histogram/public/container/hooks/use_state_props.test.ts
+++ b/src/plugins/unified_histogram/public/container/hooks/use_state_props.test.ts
@@ -14,7 +14,7 @@ import { act } from 'react-test-renderer';
 import { UnifiedHistogramFetchStatus } from '../../types';
 import { dataViewMock } from '../../__mocks__/data_view';
 import { dataViewWithTimefieldMock } from '../../__mocks__/data_view_with_timefield';
-import { allSuggestionsMock, currentSuggestionMock } from '../../__mocks__/suggestions';
+import { currentSuggestionMock } from '../../__mocks__/suggestions';
 import { unifiedHistogramServicesMock } from '../../__mocks__/services';
 import {
   createStateService,
@@ -40,7 +40,6 @@ describe('useStateProps', () => {
     totalHitsResult: undefined,
     columns: [],
     currentSuggestion: undefined,
-    allSuggestions: undefined,
   };
 
   const getStateService = (options: Omit<UnifiedHistogramStateOptions, 'services'>) => {
@@ -56,7 +55,6 @@ describe('useStateProps', () => {
     jest.spyOn(stateService, 'setLensRequestAdapter');
     jest.spyOn(stateService, 'setTotalHits');
     jest.spyOn(stateService, 'setCurrentSuggestion');
-    jest.spyOn(stateService, 'setAllSuggestions');
     return stateService;
   };
 
@@ -65,7 +63,6 @@ describe('useStateProps', () => {
     const { result } = renderHook(() => useStateProps(stateService));
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "allSuggestions": undefined,
         "breakdown": Object {
           "field": Object {
             "aggregatable": true,
@@ -80,8 +77,6 @@ describe('useStateProps', () => {
           "hidden": false,
           "timeInterval": "auto",
         },
-        "columns": Array [],
-        "currentSuggestion": undefined,
         "hits": Object {
           "status": "uninitialized",
           "total": undefined,
@@ -115,11 +110,11 @@ describe('useStateProps', () => {
     const { result } = renderHook(() => useStateProps(stateService));
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "allSuggestions": undefined,
         "breakdown": undefined,
-        "chart": undefined,
-        "columns": Array [],
-        "currentSuggestion": undefined,
+        "chart": Object {
+          "hidden": false,
+          "timeInterval": "auto",
+        },
         "hits": Object {
           "status": "uninitialized",
           "total": undefined,
@@ -146,38 +141,18 @@ describe('useStateProps', () => {
     `);
   });
 
-  it('should return the correct props when a text based language is used with Lens suggestions', () => {
+  it('should return the correct props when a text based language is used', () => {
     const stateService = getStateService({
       initialState: {
         ...initialState,
         query: { sql: 'SELECT * FROM index' },
         currentSuggestion: currentSuggestionMock,
-        allSuggestions: allSuggestionsMock,
       },
     });
     const { result } = renderHook(() => useStateProps(stateService));
-    expect(result.current.allSuggestions).toBe(allSuggestionsMock);
-    expect(result.current.currentSuggestion).toBe(currentSuggestionMock);
     expect(result.current.chart).toStrictEqual({ hidden: false, timeInterval: 'auto' });
-  });
-
-  it('should return the suggestions if text based languages', async () => {
-    const stateService = getStateService({
-      initialState: {
-        ...initialState,
-        query: { sql: 'SELECT * FROM index' },
-        columns: ['Dest', 'AvgTicketPrice'],
-      },
-    });
-
-    const { result, waitForNextUpdate } = renderHook(() =>
-      useStateProps(stateService, unifiedHistogramServicesMock)
-    );
-    await waitForNextUpdate();
-    expect(stateService.setCurrentSuggestion).toHaveBeenCalledWith(currentSuggestionMock);
-    expect(stateService.setAllSuggestions).toHaveBeenCalledWith(allSuggestionsMock);
-    expect(result.current.allSuggestions).toStrictEqual(allSuggestionsMock);
-    expect(result.current.currentSuggestion).toStrictEqual(currentSuggestionMock);
+    expect(result.current.breakdown).toBe(undefined);
+    expect(result.current.isPlainRecord).toBe(true);
   });
 
   it('should return the correct props when a rollup data view is used', () => {
@@ -193,11 +168,8 @@ describe('useStateProps', () => {
     const { result } = renderHook(() => useStateProps(stateService));
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "allSuggestions": undefined,
         "breakdown": undefined,
         "chart": undefined,
-        "columns": Array [],
-        "currentSuggestion": undefined,
         "hits": Object {
           "status": "uninitialized",
           "total": undefined,
@@ -231,11 +203,8 @@ describe('useStateProps', () => {
     const { result } = renderHook(() => useStateProps(stateService));
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "allSuggestions": undefined,
         "breakdown": undefined,
         "chart": undefined,
-        "columns": Array [],
-        "currentSuggestion": undefined,
         "hits": Object {
           "status": "uninitialized",
           "total": undefined,

--- a/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
+++ b/src/plugins/unified_histogram/public/container/hooks/use_state_props.ts
@@ -13,7 +13,6 @@ import { UnifiedHistogramChartLoadEvent, UnifiedHistogramFetchStatus } from '../
 import type { UnifiedHistogramStateService } from '../services/state_service';
 import {
   breakdownFieldSelector,
-  columnsSelector,
   chartHiddenSelector,
   dataViewSelector,
   querySelector,
@@ -22,13 +21,11 @@ import {
   timeIntervalSelector,
   totalHitsResultSelector,
   totalHitsStatusSelector,
-  currentSuggestionSelector,
 } from '../utils/state_selectors';
 import { useStateSelector } from '../utils/use_state_selector';
 
 export const useStateProps = (stateService: UnifiedHistogramStateService | undefined) => {
   const breakdownField = useStateSelector(stateService?.state$, breakdownFieldSelector);
-  const columns = useStateSelector(stateService?.state$, columnsSelector);
   const chartHidden = useStateSelector(stateService?.state$, chartHiddenSelector);
   const dataView = useStateSelector(stateService?.state$, dataViewSelector);
   const query = useStateSelector(stateService?.state$, querySelector);
@@ -37,7 +34,6 @@ export const useStateProps = (stateService: UnifiedHistogramStateService | undef
   const timeInterval = useStateSelector(stateService?.state$, timeIntervalSelector);
   const totalHitsResult = useStateSelector(stateService?.state$, totalHitsResultSelector);
   const totalHitsStatus = useStateSelector(stateService?.state$, totalHitsStatusSelector);
-  const currentSuggestion = useStateSelector(stateService?.state$, currentSuggestionSelector);
 
   /**
    * Contexts
@@ -167,8 +163,6 @@ export const useStateProps = (stateService: UnifiedHistogramStateService | undef
     chart,
     breakdown,
     request,
-    columns,
-    currentSuggestion,
     isPlainRecord,
     onTopPanelHeightChange,
     onTimeIntervalChange,

--- a/src/plugins/unified_histogram/public/container/services/state_service.test.ts
+++ b/src/plugins/unified_histogram/public/container/services/state_service.test.ts
@@ -61,7 +61,6 @@ describe('UnifiedHistogramStateService', () => {
     totalHitsResult: undefined,
     columns: [],
     currentSuggestion: undefined,
-    allSuggestions: undefined,
   };
 
   it('should initialize state with default values', () => {

--- a/src/plugins/unified_histogram/public/container/services/state_service.ts
+++ b/src/plugins/unified_histogram/public/container/services/state_service.ts
@@ -39,10 +39,6 @@ export interface UnifiedHistogramState {
    */
   currentSuggestion: Suggestion | undefined;
   /**
-   * The suggested Lens visualizations
-   */
-  allSuggestions: Suggestion[] | undefined;
-  /**
    * Whether or not the chart is hidden
    */
   chartHidden: boolean;
@@ -126,12 +122,6 @@ export interface UnifiedHistogramStateService {
    * Sets current Lens suggestion
    */
   setCurrentSuggestion: (suggestion: Suggestion | undefined) => void;
-
-  /**
-   * Sets all Lens suggestions
-   */
-  setAllSuggestions: (suggestions: Suggestion[] | undefined) => void;
-
   /**
    * Sets columns
    */
@@ -193,7 +183,6 @@ export const createStateService = (
     columns: [],
     filters: [],
     currentSuggestion: undefined,
-    allSuggestions: undefined,
     lensRequestAdapter: undefined,
     query: services.data.query.queryString.getDefaultQuery(),
     requestAdapter: undefined,
@@ -243,12 +232,9 @@ export const createStateService = (
     setCurrentSuggestion: (suggestion: Suggestion | undefined) => {
       updateState({ currentSuggestion: suggestion });
     },
+
     setColumns: (columns: string[] | undefined) => {
       updateState({ columns });
-    },
-
-    setAllSuggestions: (suggestions: Suggestion[] | undefined) => {
-      updateState({ allSuggestions: suggestions });
     },
 
     setTimeInterval: (timeInterval: string) => {

--- a/src/plugins/unified_histogram/public/container/utils/state_selectors.ts
+++ b/src/plugins/unified_histogram/public/container/utils/state_selectors.ts
@@ -22,4 +22,3 @@ export const topPanelHeightSelector = (state: UnifiedHistogramState) => state.to
 export const totalHitsResultSelector = (state: UnifiedHistogramState) => state.totalHitsResult;
 export const totalHitsStatusSelector = (state: UnifiedHistogramState) => state.totalHitsStatus;
 export const currentSuggestionSelector = (state: UnifiedHistogramState) => state.currentSuggestion;
-export const allSuggestionsSelector = (state: UnifiedHistogramState) => state.allSuggestions;

--- a/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
+++ b/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
@@ -52,15 +52,25 @@ export const useLensSuggestions = ({
 
   const [allSuggestions, setAllSuggestions] = useState(suggestions.restSuggestions);
   const currentSuggestion = originalSuggestion ?? suggestions.firstSuggestion;
-  const previousColumn = useRef(columns);
+  const suggestionDeps = useRef(getSuggestionDeps({ dataView, query, columns }));
 
   useEffect(() => {
-    if (!isEqual(columns, previousColumn.current)) {
+    const newSuggestionsDeps = getSuggestionDeps({ dataView, query, columns });
+
+    if (!isEqual(suggestionDeps.current, newSuggestionsDeps)) {
       setAllSuggestions(suggestions.restSuggestions);
       onSuggestionChange?.(suggestions.firstSuggestion);
-      previousColumn.current = columns;
+
+      suggestionDeps.current = newSuggestionsDeps;
     }
-  }, [columns, onSuggestionChange, suggestions.firstSuggestion, suggestions.restSuggestions]);
+  }, [
+    columns,
+    dataView,
+    onSuggestionChange,
+    query,
+    suggestions.firstSuggestion,
+    suggestions.restSuggestions,
+  ]);
 
   return {
     allSuggestions,
@@ -70,3 +80,13 @@ export const useLensSuggestions = ({
       (!currentSuggestion || currentSuggestion?.visualizationId === 'lnsDatatable'),
   };
 };
+
+const getSuggestionDeps = ({
+  dataView,
+  query,
+  columns,
+}: {
+  dataView: DataView;
+  query?: Query | AggregateQuery;
+  columns?: string[];
+}) => [dataView.id, columns, query];

--- a/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
+++ b/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { DataView } from '@kbn/data-views-plugin/common';
+import { AggregateQuery, isOfAggregateQueryType, Query } from '@kbn/es-query';
+import { LensSuggestionsApi, Suggestion } from '@kbn/lens-plugin/public';
+import { isEqual } from 'lodash';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+export const useLensSuggestions = ({
+  dataView,
+  query,
+  originalSuggestion,
+  isPlainRecord,
+  columns,
+  lensSuggestionsApi,
+  onSuggestionChange,
+}: {
+  dataView: DataView;
+  query?: Query | AggregateQuery;
+  originalSuggestion?: Suggestion;
+  isPlainRecord?: boolean;
+  columns?: string[];
+  lensSuggestionsApi: LensSuggestionsApi;
+  onSuggestionChange?: (suggestion: Suggestion | undefined) => void;
+}) => {
+  const suggestions = useMemo(() => {
+    const context = {
+      dataViewSpec: dataView?.toSpec(),
+      fieldName: '',
+      contextualFields: columns,
+      query: query && isOfAggregateQueryType(query) ? query : undefined,
+    };
+    const lensSuggestions = isPlainRecord ? lensSuggestionsApi(context, dataView) : undefined;
+    const firstSuggestion = lensSuggestions?.length ? lensSuggestions[0] : undefined;
+    const restSuggestions = lensSuggestions?.filter((sug) => {
+      return !sug.hide && sug.visualizationId !== 'lnsLegacyMetric';
+    });
+    const firstSuggestionExists = restSuggestions?.find(
+      (sug) => sug.title === firstSuggestion?.title
+    );
+    if (firstSuggestion && !firstSuggestionExists) {
+      restSuggestions?.push(firstSuggestion);
+    }
+    return { firstSuggestion, restSuggestions };
+  }, [columns, dataView, isPlainRecord, lensSuggestionsApi, query]);
+
+  const [allSuggestions, setAllSuggestions] = useState(suggestions.restSuggestions);
+  const currentSuggestion = originalSuggestion ?? suggestions.firstSuggestion;
+  const previousColumn = useRef(columns);
+
+  useEffect(() => {
+    if (!isEqual(columns, previousColumn.current)) {
+      setAllSuggestions(suggestions.restSuggestions);
+      onSuggestionChange?.(suggestions.firstSuggestion);
+      previousColumn.current = columns;
+    }
+  }, [columns, onSuggestionChange, suggestions.firstSuggestion, suggestions.restSuggestions]);
+
+  return {
+    allSuggestions,
+    currentSuggestion,
+    suggestionUnsupported:
+      isPlainRecord &&
+      (!currentSuggestion || currentSuggestion?.visualizationId === 'lnsDatatable'),
+  };
+};

--- a/src/plugins/unified_histogram/public/layout/layout.test.tsx
+++ b/src/plugins/unified_histogram/public/layout/layout.test.tsx
@@ -76,6 +76,7 @@ describe('Layout', () => {
           from: '2020-05-14T11:05:13.590',
           to: '2020-05-14T11:20:13.590',
         }}
+        lensSuggestionsApi={jest.fn()}
         {...rest}
       />
     );

--- a/src/plugins/unified_histogram/public/layout/layout.tsx
+++ b/src/plugins/unified_histogram/public/layout/layout.tsx
@@ -7,13 +7,13 @@
  */
 
 import { EuiSpacer, useEuiTheme, useIsWithinBreakpoints } from '@elastic/eui';
-import type { PropsWithChildren, ReactElement, RefObject } from 'react';
+import { PropsWithChildren, ReactElement, RefObject } from 'react';
 import React, { useMemo } from 'react';
 import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
 import { css } from '@emotion/css';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
-import type { LensEmbeddableInput, Suggestion } from '@kbn/lens-plugin/public';
-import type { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
+import type { LensEmbeddableInput, LensSuggestionsApi, Suggestion } from '@kbn/lens-plugin/public';
+import { AggregateQuery, Filter, Query, TimeRange } from '@kbn/es-query';
 import { Chart } from '../chart';
 import { Panels, PANELS_MODE } from '../panels';
 import type {
@@ -26,6 +26,7 @@ import type {
   UnifiedHistogramChartLoadEvent,
   UnifiedHistogramInput$,
 } from '../types';
+import { useLensSuggestions } from './hooks/use_lens_suggestions';
 
 export interface UnifiedHistogramLayoutProps extends PropsWithChildren<unknown> {
   /**
@@ -53,10 +54,6 @@ export interface UnifiedHistogramLayoutProps extends PropsWithChildren<unknown> 
    */
   currentSuggestion?: Suggestion;
   /**
-   * The suggested Lens visualizations
-   */
-  allSuggestions?: Suggestion[];
-  /**
    * Flag that indicates that a text based language is used
    */
   isPlainRecord?: boolean;
@@ -64,6 +61,7 @@ export interface UnifiedHistogramLayoutProps extends PropsWithChildren<unknown> 
    * The current time range
    */
   timeRange?: TimeRange;
+  columns?: string[];
   /**
    * Context object for requests made by Unified Histogram components -- optional
    */
@@ -108,6 +106,10 @@ export interface UnifiedHistogramLayoutProps extends PropsWithChildren<unknown> 
    * Input observable
    */
   input$?: UnifiedHistogramInput$;
+  /**
+   * The Lens suggestions API
+   */
+  lensSuggestionsApi: LensSuggestionsApi;
   /**
    * Callback to get the relative time range, useful when passing an absolute time range (e.g. for edit visualization button)
    */
@@ -157,13 +159,13 @@ export const UnifiedHistogramLayout = ({
   dataView,
   query,
   filters,
-  currentSuggestion,
-  allSuggestions,
+  currentSuggestion: originalSuggestion,
   isPlainRecord,
   timeRange,
+  columns,
   request,
   hits,
-  chart,
+  chart: originalChart,
   breakdown,
   resizeRef,
   topPanelHeight,
@@ -171,6 +173,7 @@ export const UnifiedHistogramLayout = ({
   disableAutoFetching,
   disableTriggers,
   disabledActions,
+  lensSuggestionsApi,
   input$,
   getRelativeTimeRange,
   onTopPanelHeightChange,
@@ -184,6 +187,18 @@ export const UnifiedHistogramLayout = ({
   onBrushEnd,
   children,
 }: UnifiedHistogramLayoutProps) => {
+  const { allSuggestions, currentSuggestion, suggestionUnsupported } = useLensSuggestions({
+    dataView,
+    query,
+    originalSuggestion,
+    isPlainRecord,
+    columns,
+    lensSuggestionsApi,
+    onSuggestionChange,
+  });
+
+  const chart = suggestionUnsupported ? undefined : originalChart;
+
   const topPanelNode = useMemo(
     () => createHtmlPortalNode({ attributes: { class: 'eui-fullHeight' } }),
     []

--- a/src/plugins/unified_histogram/public/layout/layout.tsx
+++ b/src/plugins/unified_histogram/public/layout/layout.tsx
@@ -61,6 +61,9 @@ export interface UnifiedHistogramLayoutProps extends PropsWithChildren<unknown> 
    * The current time range
    */
   timeRange?: TimeRange;
+  /**
+   * The current columns
+   */
   columns?: string[];
   /**
    * Context object for requests made by Unified Histogram components -- optional

--- a/src/plugins/unified_histogram/public/types.ts
+++ b/src/plugins/unified_histogram/public/types.ts
@@ -17,6 +17,7 @@ import type { DefaultInspectorAdapters } from '@kbn/expressions-plugin/common';
 import type { Subject } from 'rxjs';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
 
 /**
  * The fetch status of a Unified Histogram request
@@ -40,6 +41,7 @@ export interface UnifiedHistogramServices {
   fieldFormats: FieldFormatsStart;
   lens: LensPublicStart;
   storage: Storage;
+  expressions: ExpressionsStart;
 }
 
 /**

--- a/x-pack/plugins/lens/public/index.ts
+++ b/x-pack/plugins/lens/public/index.ts
@@ -110,6 +110,6 @@ export type { ChartInfo } from './chart_info_api';
 export { layerTypes } from '../common/layer_types';
 export { LENS_EMBEDDABLE_TYPE } from '../common/constants';
 
-export type { LensPublicStart, LensPublicSetup } from './plugin';
+export type { LensPublicStart, LensPublicSetup, LensSuggestionsApi } from './plugin';
 
 export const plugin = () => new LensPlugin();

--- a/x-pack/plugins/lens/public/plugin.ts
+++ b/x-pack/plugins/lens/public/plugin.ts
@@ -235,12 +235,14 @@ export interface LensPublicStart {
   stateHelperApi: () => Promise<{
     formula: FormulaPublicApi;
     chartInfo: ChartInfoApi;
-    suggestionsApi: (
-      context: VisualizeFieldContext | VisualizeEditorContext,
-      dataViews: DataView
-    ) => Suggestion[] | undefined;
+    suggestionsApi: LensSuggestionsApi;
   }>;
 }
+
+export type LensSuggestionsApi = (
+  context: VisualizeFieldContext | VisualizeEditorContext,
+  dataViews: DataView
+) => Suggestion[] | undefined;
 
 export class LensPlugin {
   private datatableVisualization: DatatableVisualizationType | undefined;


### PR DESCRIPTION
A few suggestions I think could help cleanup the Unified Histogram text-based work:
- [Make text based total hits state internal to Unified Histogram](https://github.com/stratoula/kibana/commit/6b82e9c4fb9948fff63041d905752400ba0c0c71)
- [Call timefilter.getAbsoluteTime to get timeRange](https://github.com/stratoula/kibana/commit/ebd2288f32b49cbb23e0340e3fd9f0d35e211c9c)
- [Revert changes to use_lens_props to respect refetch$](https://github.com/stratoula/kibana/commit/10d70f3800e0a4bbb438406949b76e5f112e99c2)