### PR TITLE
Design - [Text based] Configure Lens suggestion on the fly from Discover

### DIFF
--- a/src/plugins/unified_histogram/public/chart/histogram.tsx
+++ b/src/plugins/unified_histogram/public/chart/histogram.tsx
@@ -146,6 +146,7 @@ export function Histogram({
   const chartCss = css`
     position: relative;
     flex-grow: 1;
+    margin-block: ${euiTheme.size.xs};
 
     & > div {
       height: 100%;

--- a/x-pack/plugins/lens/public/app_plugin/app.scss
+++ b/x-pack/plugins/lens/public/app_plugin/app.scss
@@ -38,3 +38,7 @@
     }
   }
 }
+
+.lnsEditConfigurationFlyout {
+  background: none;
+}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
@@ -113,6 +113,7 @@ export function getEditLensConfiguration(
           defaultMessage: 'Edit configuration',
         })}
         size="s"
+        className="lnsEditConfigurationFlyout"
         hideCloseButton
       >
         <Provider store={lensStore}>

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -7,7 +7,9 @@
 
 import React, { useMemo } from 'react';
 import {
+  EuiButtonEmpty,
   EuiFlyoutBody,
+  EuiFlyoutFooter,
   EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,6 +18,7 @@ import {
   EuiCallOut,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import type { CoreStart } from '@kbn/core/public';
 import type { Datatable } from '@kbn/expressions-plugin/public';
@@ -125,46 +128,48 @@ export function LensEditConfigurationFlyout({
     onUpdateStateCb: updateAll,
   };
   return (
-    <EuiFlyoutBody
-      className="lnsEditFlyoutBody"
-      css={css`
-        .euiFlyoutBody__overflowContent {
-          padding: ${euiTheme.size.s};
-        }
-      `}
-    >
-      <EuiFlexGroup gutterSize="s">
-        <EuiFlexItem grow={false}>
-          <EuiButtonIcon
-            iconType="menuRight"
-            iconSize="m"
-            size="xs"
-            onClick={closeFlyout}
-            data-test-subj="collapseFlyoutButton"
-            aria-controls="lens-config-close-button"
-            aria-expanded="true"
-            aria-label={i18n.translate('xpack.lens.config.closeFlyoutAriaLabel', {
-              defaultMessage: 'Close flyout',
-            })}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCallOut
-            title={i18n.translate('xpack.lens.config.configFlyoutCallout', {
-              defaultMessage: 'SQL currently offers limited configuration options',
-            })}
-            iconType="iInCircle"
-          />
-          <EuiSpacer size="m" />
-          <VisualizationToolbar
-            activeVisualization={activeVisualization}
-            framePublicAPI={framePublicAPI}
-            onUpdateStateCb={updateAll}
-          />
-          <EuiSpacer size="m" />
-          <ConfigPanelWrapper {...layerPanelsProps} />
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </EuiFlyoutBody>
+    <>
+      <EuiFlyoutBody
+        className="lnsEditFlyoutBody"
+        css={css`
+          .euiFlyoutBody__overflowContent {
+            padding: ${euiTheme.size.s};
+          }
+        `}
+      >
+        <EuiFlexGroup gutterSize="s">
+          <EuiFlexItem>
+            <EuiCallOut
+              size="s"
+              title={i18n.translate('xpack.lens.config.configFlyoutCallout', {
+                defaultMessage: 'SQL currently offers limited configuration options',
+              })}
+              iconType="iInCircle"
+            />
+            <EuiSpacer size="m" />
+            <VisualizationToolbar
+              activeVisualization={activeVisualization}
+              framePublicAPI={framePublicAPI}
+              onUpdateStateCb={updateAll}
+            />
+            <EuiSpacer size="m" />
+            <ConfigPanelWrapper {...layerPanelsProps} />
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlyoutBody>
+      <EuiFlyoutFooter>
+        <EuiButtonEmpty
+          onClick={closeFlyout}
+          data-test-subj="collapseFlyoutButton"
+          aria-controls="lens-config-close-button"
+          aria-expanded="true"
+          aria-label={i18n.translate('xpack.lens.config.closeFlyoutAriaLabel', {
+            defaultMessage: 'Close flyout',
+          })}
+        >
+          <FormattedMessage id="xpack.lens.config.closeFlyoutLabel" defaultMessage="Close" />
+        </EuiButtonEmpty>
+      </EuiFlyoutFooter>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

### This PR:

- Removes the `menuRight` icon in the flyout (it was causing empty space on the left side of the flyout which looked off). Instead, we should use a footer with the `Close` button. Doing this will also align us better with the Lens flyout in Dashboard (which will also have a footer).
- Reduces the size of the callout
- Adds some margin around the histogram for better display of charts (esp. the waffle one)
- Gives the flyout the same gray background as the rest of Discover (again to be better aligned with the upcoming Dashboard flyout)

### Result:

<img width="1279" alt="image" src="https://github.com/stratoula/kibana/assets/4016496/dcee4a59-8833-4a6a-8981-abce5bff208f">

### Before
<img width="1281" alt="image" src="https://github.com/stratoula/kibana/assets/4016496/3d5d9318-6111-4ace-bb9c-7d3c82c0123b">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
