### PR TITLE
[ES|QL] Change layout of inline docs flyout header

### DIFF
--- a/packages/kbn-language-documentation-popover/src/components/as_flyout/index.tsx
+++ b/packages/kbn-language-documentation-popover/src/components/as_flyout/index.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiTitle,
-  EuiSpacer
+  EuiSpacer,
 } from '@elastic/eui';
 import { getFilteredGroups } from '../../utils/get_filtered_groups';
 import { DocumentationMainContent, DocumentationNavigation } from '../shared';
@@ -79,12 +79,13 @@ function DocumentationFlyout({
           aria-labelledby="esqlInlineDocumentationFlyout"
           type="push"
           size={DEFAULT_WIDTH}
+          paddingSize="m"
         >
           <EuiFlyoutHeader hasBorder>
-            <EuiTitle size="m">
+            <EuiTitle size="s">
               <h3>ES|QL quick reference</h3>
             </EuiTitle>
-            <EuiSpacer size="s" />
+            <EuiSpacer size="m" />
             <DocumentationNavigation
               searchText={searchText}
               setSearchText={setSearchText}

--- a/packages/kbn-language-documentation-popover/src/components/as_flyout/index.tsx
+++ b/packages/kbn-language-documentation-popover/src/components/as_flyout/index.tsx
@@ -7,7 +7,14 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React, { useCallback, useEffect, useState, useRef, useMemo } from 'react';
-import { EuiFlyout, useEuiTheme, EuiFlyoutBody, EuiFlyoutHeader } from '@elastic/eui';
+import {
+  EuiFlyout,
+  useEuiTheme,
+  EuiFlyoutBody,
+  EuiFlyoutHeader,
+  EuiTitle,
+  EuiSpacer
+} from '@elastic/eui';
 import { getFilteredGroups } from '../../utils/get_filtered_groups';
 import { DocumentationMainContent, DocumentationNavigation } from '../shared';
 import { getESQLDocsSections } from '../../sections';
@@ -74,6 +81,10 @@ function DocumentationFlyout({
           size={DEFAULT_WIDTH}
         >
           <EuiFlyoutHeader hasBorder>
+            <EuiTitle size="m">
+              <h3>ES|QL quick reference</h3>
+            </EuiTitle>
+            <EuiSpacer size="s" />
             <DocumentationNavigation
               searchText={searchText}
               setSearchText={setSearchText}

--- a/packages/kbn-language-documentation-popover/src/components/shared/documentation_navigation.tsx
+++ b/packages/kbn-language-documentation-popover/src/components/shared/documentation_navigation.tsx
@@ -7,7 +7,17 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { EuiFlexItem, EuiFlexGroup, EuiFormRow, EuiLink, EuiText, EuiComboBox } from '@elastic/eui';
+import { css } from '@emotion/react';
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiFormRow,
+  EuiLink,
+  EuiText,
+  useEuiTheme,
+  EuiFieldSearch,
+  EuiComboBox,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 interface DocumentationNavProps {
@@ -20,50 +30,72 @@ interface DocumentationNavProps {
 }
 
 function DocumentationNav({
+  searchText,
+  setSearchText,
   onNavigationChange,
   filteredGroups,
   linkToDocumentation,
   selectedSection,
 }: DocumentationNavProps) {
+  const { euiTheme } = useEuiTheme();
 
   return (
     <>
-      <EuiFlexGroup gutterSize="s" responsive={false} direction="row" alignItems="center">
+      <EuiFlexGroup gutterSize="none" responsive={false} direction="column">
         <EuiFlexItem grow={true}>
-          <EuiFormRow
+        <EuiFormRow
+          fullWidth
+          label="Select or search topics"
+          labelAppend={linkToDocumentation && (
+            <EuiText size="xs">
+              <EuiLink
+                external
+                href={linkToDocumentation}
+                target="_blank"
+                data-test-subj="language-documentation-navigation-link"
+              >
+                {i18n.translate('languageDocumentationPopover.esqlDocsLabel', {
+                  defaultMessage: 'View full ES|QL documentation',
+                })}
+              </EuiLink>
+            </EuiText>
+            )}
+          >
+          <EuiComboBox
+            aria-label={i18n.translate('languageDocumentationPopover.navigationAriaLabel', {
+              defaultMessage: 'Navigate through the documentation',
+            })}
+            placeholder={i18n.translate('languageDocumentationPopover.navigationPlaceholder', {
+              defaultMessage: 'Commands and functions',
+            })}
+            data-test-subj="language-documentation-navigation-dropdown"
+            options={filteredGroups}
+            selectedOptions={selectedSection ? [{ label: selectedSection }] : []}
+            singleSelection={{ asPlainText: true }}
+            onChange={onNavigationChange}
+            compressed
             fullWidth
-            label="Search or select topic"
-            labelAppend={linkToDocumentation && (
-              <EuiText size="xs">
-                <EuiLink
-                  external
-                  href={linkToDocumentation}
-                  target="_blank"
-                  data-test-subj="language-documentation-navigation-link"
-                >
-                  {i18n.translate('languageDocumentationPopover.esqlDocsLabel', {
-                    defaultMessage: 'View full ES|QL documentation',
-                  })}
-                </EuiLink>
-              </EuiText>
-              )}
-            >
-            <EuiComboBox
-              aria-label={i18n.translate('languageDocumentationPopover.navigationAriaLabel', {
-                defaultMessage: 'Navigate through the documentation',
-              })}
-              placeholder={i18n.translate('languageDocumentationPopover.navigationPlaceholder', {
-                defaultMessage: 'Commands and functions',
-              })}
-              data-test-subj="language-documentation-navigation-dropdown"
-              options={filteredGroups}
-              selectedOptions={selectedSection ? [{ label: selectedSection }] : []}
-              singleSelection={{ asPlainText: true }}
-              onChange={onNavigationChange}
-              compressed
-              fullWidth
-            />
+          />
           </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            padding: ${euiTheme.size.s} 0;
+          `}
+        >
+          <EuiFieldSearch
+            value={searchText}
+            onChange={(e) => {
+              setSearchText(e.target.value);
+            }}
+            data-test-subj="language-documentation-navigation-search"
+            placeholder={i18n.translate('languageDocumentationPopover.searchPlaceholder', {
+              defaultMessage: 'Search',
+            })}
+            fullWidth
+            compressed
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/packages/kbn-language-documentation-popover/src/components/shared/documentation_navigation.tsx
+++ b/packages/kbn-language-documentation-popover/src/components/shared/documentation_navigation.tsx
@@ -7,15 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 import React from 'react';
-import { css } from '@emotion/react';
-import {
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiLink,
-  useEuiTheme,
-  EuiFieldSearch,
-  EuiComboBox,
-} from '@elastic/eui';
+import { EuiFlexItem, EuiFlexGroup, EuiFormRow, EuiLink, EuiText, EuiComboBox } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 interface DocumentationNavProps {
@@ -28,73 +20,50 @@ interface DocumentationNavProps {
 }
 
 function DocumentationNav({
-  searchText,
-  setSearchText,
   onNavigationChange,
   filteredGroups,
   linkToDocumentation,
   selectedSection,
 }: DocumentationNavProps) {
-  const { euiTheme } = useEuiTheme();
 
   return (
     <>
-      {linkToDocumentation && (
-        <EuiFlexItem
-          grow={false}
-          css={css`
-            align-items: flex-end;
-            padding-top: ${euiTheme.size.xs};
-          `}
-        >
-          <EuiLink
-            external
-            href={linkToDocumentation}
-            target="_blank"
-            data-test-subj="language-documentation-navigation-link"
-          >
-            {i18n.translate('languageDocumentationPopover.esqlDocsLabel', {
-              defaultMessage: 'View full ES|QL documentation',
-            })}
-          </EuiLink>
-        </EuiFlexItem>
-      )}
-      <EuiFlexGroup gutterSize="none" responsive={false} direction="column">
-        <EuiFlexItem
-          grow={false}
-          css={css`
-            padding: ${euiTheme.size.s} 0;
-          `}
-        >
-          <EuiFieldSearch
-            value={searchText}
-            onChange={(e) => {
-              setSearchText(e.target.value);
-            }}
-            data-test-subj="language-documentation-navigation-search"
-            placeholder={i18n.translate('languageDocumentationPopover.searchPlaceholder', {
-              defaultMessage: 'Search',
-            })}
+      <EuiFlexGroup gutterSize="s" responsive={false} direction="row" alignItems="center">
+        <EuiFlexItem grow={true}>
+          <EuiFormRow
             fullWidth
-            compressed
-          />
-        </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiComboBox
-            aria-label={i18n.translate('languageDocumentationPopover.navigationAriaLabel', {
-              defaultMessage: 'Navigate through the documentation',
-            })}
-            placeholder={i18n.translate('languageDocumentationPopover.navigationPlaceholder', {
-              defaultMessage: 'Commands and functions',
-            })}
-            data-test-subj="language-documentation-navigation-dropdown"
-            options={filteredGroups}
-            selectedOptions={selectedSection ? [{ label: selectedSection }] : []}
-            singleSelection={{ asPlainText: true }}
-            onChange={onNavigationChange}
-            compressed
-            fullWidth
-          />
+            label="Search or select topic"
+            labelAppend={linkToDocumentation && (
+              <EuiText size="xs">
+                <EuiLink
+                  external
+                  href={linkToDocumentation}
+                  target="_blank"
+                  data-test-subj="language-documentation-navigation-link"
+                >
+                  {i18n.translate('languageDocumentationPopover.esqlDocsLabel', {
+                    defaultMessage: 'View full ES|QL documentation',
+                  })}
+                </EuiLink>
+              </EuiText>
+              )}
+            >
+            <EuiComboBox
+              aria-label={i18n.translate('languageDocumentationPopover.navigationAriaLabel', {
+                defaultMessage: 'Navigate through the documentation',
+              })}
+              placeholder={i18n.translate('languageDocumentationPopover.navigationPlaceholder', {
+                defaultMessage: 'Commands and functions',
+              })}
+              data-test-subj="language-documentation-navigation-dropdown"
+              options={filteredGroups}
+              selectedOptions={selectedSection ? [{ label: selectedSection }] : []}
+              singleSelection={{ asPlainText: true }}
+              onChange={onNavigationChange}
+              compressed
+              fullWidth
+            />
+          </EuiFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/192156#pullrequestreview-2307334756

## Summary
- Add flyout header title
- Use EuiFormRow to improve layout of full docs link
- ~Removed the search input~ (update: put this back in light of the thread about highlighting the found text)

### Result

![CleanShot 2024-09-16 at 11 26 09@2x](https://github.com/user-attachments/assets/e86d9e4b-e95c-4a0b-9195-ad7352a709b7)