### PR TITLE
[ES|QL controls] Design cleanup #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ report.asciidoc
 
 # Yarn local mirror content
 .yarn-local-mirror
+.yarn
 
 # Bazel
 .ijwb

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,6 @@ report.asciidoc
 
 # Yarn local mirror content
 .yarn-local-mirror
-.yarn
 
 # Bazel
 .ijwb

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/choose_column_popover.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/choose_column_popover.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiLink, EuiPopover, EuiSelectable, EuiSelectableOption } from '@elastic/eui';
+import { css } from '@emotion/react';
 
 export function ChooseColumnPopover({
   columns,
@@ -27,7 +28,13 @@ export function ChooseColumnPopover({
   const closePopover = () => setIsPopoverOpen(false);
 
   const button = (
-    <EuiLink onClick={onButtonClick} data-test-subj="chooseColumnBtn">
+    <EuiLink
+      css={css`
+        vertical-align: top;
+      `}
+      onClick={onButtonClick}
+      data-test-subj="chooseColumnBtn"
+    >
       {i18n.translate('esql.flyout.chooseColumnBtn.label', {
         defaultMessage: 'here',
       })}

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/shared_form_components.tsx
@@ -28,6 +28,8 @@ import {
   EuiTitle,
   EuiBetaBadge,
   EuiToolTip,
+  EuiText,
+  EuiTextColor,
 } from '@elastic/eui';
 import { esqlVariablesService } from '@kbn/esql-variables/common';
 import { EsqlControlType } from '../types';
@@ -198,9 +200,15 @@ export function ControlLabel({
       label={i18n.translate('esql.flyout.label.label', {
         defaultMessage: 'Label',
       })}
-      labelAppend={i18n.translate('esql.flyout.label.extraLabel', {
-        defaultMessage: 'Optional',
-      })}
+      labelAppend={
+        <EuiText size="xs">
+          <EuiTextColor color="subdued">
+            {i18n.translate('esql.flyout.label.extraLabel', {
+              defaultMessage: 'Optional',
+            })}
+          </EuiTextColor>
+        </EuiText>
+      }
       fullWidth
     >
       <EuiFieldText
@@ -269,9 +277,9 @@ export function ControlWidth({
 export function Header() {
   return (
     <EuiFlyoutHeader hasBorder>
-      <EuiFlexGroup alignItems="center" responsive={false}>
+      <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
         <EuiFlexItem grow={false}>
-          <EuiTitle size="m">
+          <EuiTitle size="xs">
             <h2>
               {i18n.translate('esql.flyout.title', {
                 defaultMessage: 'Create ES|QL control',

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -379,7 +379,6 @@ export function ValueControlForm({
                 {queryColumns.length === 1 ? (
                   <EuiPanel
                     paddingSize="s"
-                    // hasBorder
                     color="primary"
                     css={css`
                       white-space: wrap;

--- a/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
+++ b/src/platform/plugins/shared/esql/public/triggers/esql_controls/control_flyout/value_control_form.tsx
@@ -376,45 +376,45 @@ export function ValueControlForm({
                 })}
                 fullWidth
               >
-                <EuiPanel
-                  paddingSize="s"
-                  hasBorder
-                  css={css`
-                    white-space: wrap;
-                    overflow-y: auto;
-                    max-height: 200px;
-                  `}
-                  data-test-subj="esqlValuesPreview"
-                >
-                  {queryColumns.length === 1 ? (
-                    selectedValues.map((value) => value.label).join(', ')
-                  ) : (
-                    <EuiCallOut
-                      title={i18n.translate('esql.flyout.displayMultipleColsCallout.title', {
-                        defaultMessage: 'Your query must return a single column',
-                      })}
-                      iconType="warning"
-                      data-test-subj="esqlMoreThanOneColumnCallout"
-                    >
-                      <p>
-                        <FormattedMessage
-                          id="esql.flyout.displayMultipleColsCallout.description"
-                          defaultMessage="Your query is currently returning {totalColumns} columns. Choose column {chooseColumnPopover} or use {boldText}."
-                          values={{
-                            totalColumns: queryColumns.length,
-                            boldText: <strong>STATS BY</strong>,
-                            chooseColumnPopover: (
-                              <ChooseColumnPopover
-                                columns={queryColumns}
-                                updateQuery={updateQuery}
-                              />
-                            ),
-                          }}
-                        />
-                      </p>
-                    </EuiCallOut>
-                  )}
-                </EuiPanel>
+                {queryColumns.length === 1 ? (
+                  <EuiPanel
+                    paddingSize="s"
+                    // hasBorder
+                    color="primary"
+                    css={css`
+                      white-space: wrap;
+                      overflow-y: auto;
+                      max-height: 200px;
+                    `}
+                    data-test-subj="esqlValuesPreview"
+                  >
+                    {selectedValues.map((value) => value.label).join(', ')}
+                  </EuiPanel>
+                ) : (
+                  <EuiCallOut
+                    title={i18n.translate('esql.flyout.displayMultipleColsCallout.title', {
+                      defaultMessage: 'Your query must return a single column',
+                    })}
+                    color="warning"
+                    iconType="warning"
+                    size="s"
+                    data-test-subj="esqlMoreThanOneColumnCallout"
+                  >
+                    <p>
+                      <FormattedMessage
+                        id="esql.flyout.displayMultipleColsCallout.description"
+                        defaultMessage="Your query is currently returning {totalColumns} columns. Choose column {chooseColumnPopover} or use {boldText}."
+                        values={{
+                          totalColumns: queryColumns.length,
+                          boldText: <strong>STATS BY</strong>,
+                          chooseColumnPopover: (
+                            <ChooseColumnPopover columns={queryColumns} updateQuery={updateQuery} />
+                          ),
+                        }}
+                      />
+                    </p>
+                  </EuiCallOut>
+                )}
               </EuiFormRow>
             )}
           </>


### PR DESCRIPTION
## Summary

- Adjusted heading size in flyout
- Updated the color and size of callout in the _query is returning more than one column_ scenario. Color changed from `primary` to `warning`.
<img width="896" alt="image" src="https://github.com/user-attachments/assets/0bbba4f9-074b-4aef-a68a-7a12660de61f" />

- Updated the style of the `Values preview` panel (to `primary` background) to prevent it from looking too much like an interactive input.
<img width="953" alt="image" src="https://github.com/user-attachments/assets/9326b15c-88eb-427e-af9b-ae013245d0b0" />


- Aligned the "here" link with the rest of the callout text.
- Fixed styling of `Optional` text in inputs.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
