### PR TITLE
[ES|QL] Move the controls from the Discover app to Dashboards

### DIFF
--- a/src/platform/packages/shared/kbn-esql-types/index.ts
+++ b/src/platform/packages/shared/kbn-esql-types/index.ts
@@ -18,6 +18,7 @@ export {
   type PublishesESQLVariables,
   apiPublishesESQLVariable,
   apiPublishesESQLVariables,
+  controlHasVariableName,
 } from './src/variables_types';
 
 export {

--- a/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
+++ b/src/platform/packages/shared/kbn-esql-types/src/variables_types.ts
@@ -74,3 +74,11 @@ export const apiPublishesESQLVariables = (
     unknownApi && (unknownApi as PublishesESQLVariables)?.esqlVariables$ !== undefined
   );
 };
+
+interface HasVariableName {
+  variableName: string;
+}
+
+export const controlHasVariableName = (controlState: unknown): controlState is HasVariableName => {
+  return Boolean(controlState && (controlState as HasVariableName)?.variableName !== undefined);
+};

--- a/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
+++ b/src/platform/packages/shared/kbn-unified-histogram/components/chart/chart.tsx
@@ -28,8 +28,9 @@ import type { TimeRange } from '@kbn/es-query';
 import { PublishingSubject } from '@kbn/presentation-publishing';
 import type { RequestStatus } from '@kbn/inspector-plugin/public';
 import { IKibanaSearchResponse } from '@kbn/search-types';
-import type { ESQLControlVariable } from '@kbn/esql-types';
+import type { ESQLControlState, ESQLControlVariable } from '@kbn/esql-types';
 import type { estypes } from '@elastic/elasticsearch';
+import { ControlPanelsState } from '@kbn/controls-plugin/common';
 import { Histogram } from './histogram';
 import {
   UnifiedHistogramSuggestionContext,
@@ -91,6 +92,7 @@ export interface UnifiedHistogramChartProps {
   withDefaultActions?: EmbeddableComponentProps['withDefaultActions'];
   columns?: DatatableColumn[];
   esqlVariables?: ESQLControlVariable[];
+  controlsState?: ControlPanelsState<ESQLControlState>;
 }
 
 const RequestStatusError: typeof RequestStatus.ERROR = 2;
@@ -119,6 +121,7 @@ export function UnifiedHistogramChart({
   onTotalHitsChange,
   onChartLoad,
   columns,
+  controlsState,
   ...histogramProps
 }: UnifiedHistogramChartProps) {
   const lensVisServiceCurrentSuggestionContext = useObservable(
@@ -428,6 +431,7 @@ export function UnifiedHistogramChart({
           onSave={() => {}}
           onClose={() => setIsSaveModalVisible(false)}
           isSaveable={false}
+          controlsInput={controlsState}
         />
       )}
       {isFlyoutVisible && !!visContext && !!lensVisServiceCurrentSuggestionContext && (

--- a/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
+++ b/src/platform/packages/shared/kbn-unified-histogram/hooks/use_unified_histogram.ts
@@ -17,11 +17,12 @@ import type {
 import { useEffect, useMemo, useState } from 'react';
 import { Observable, Subject, of } from 'rxjs';
 import useMount from 'react-use/lib/useMount';
-import type { ESQLControlVariable } from '@kbn/esql-types';
+import type { ESQLControlState, ESQLControlVariable } from '@kbn/esql-types';
 import { cloneDeep, pick } from 'lodash';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import useObservable from 'react-use/lib/useObservable';
 import useLatest from 'react-use/lib/useLatest';
+import type { ControlPanelsState } from '@kbn/controls-plugin/common';
 import { UnifiedHistogramChartProps } from '../components/chart/chart';
 import {
   UnifiedHistogramExternalVisContextStatus,
@@ -81,6 +82,11 @@ export type UseUnifiedHistogramProps = Omit<UnifiedHistogramStateOptions, 'servi
    * The ES|QL variables to use for the chart
    */
   esqlVariables?: ESQLControlVariable[];
+
+  /**
+   * The current state of the controls
+   */
+  controlsState?: ControlPanelsState<ESQLControlState>;
   /**
    * The external custom Lens vis
    */
@@ -211,6 +217,7 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
     table,
     externalVisContext,
     esqlVariables,
+    controlsState,
   } = props;
   const initialBreakdownField = useMemo(
     () =>
@@ -311,6 +318,7 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
           esqlVariables,
           input$,
           chart,
+          controlsState,
           isChartAvailable,
           requestParams,
           lensVisService,
@@ -325,6 +333,7 @@ export const useUnifiedHistogram = (props: UseUnifiedHistogramProps): UseUnified
     requestParams,
     stateProps,
     esqlVariables,
+    controlsState,
   ]);
   const layoutProps = useMemo<UnifiedHistogramPartialLayoutProps>(
     () => ({

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/get_dashboard_api.ts
@@ -10,6 +10,8 @@
 import type { Reference } from '@kbn/content-management-utils';
 import { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import { BehaviorSubject, debounceTime, merge } from 'rxjs';
+import { CONTROLS_GROUP_TYPE } from '@kbn/controls-constants';
+import type { ControlsGroupState } from '@kbn/controls-schemas';
 import { v4 } from 'uuid';
 import { DASHBOARD_APP_ID } from '../../common/constants';
 import { getReferencesForControls, getReferencesForPanelId } from '../../common';
@@ -43,13 +45,13 @@ import { initializeViewModeManager } from './view_mode_manager';
 
 export function getDashboardApi({
   creationOptions,
-  incomingEmbeddable,
+  incomingEmbeddables,
   initialState,
   savedObjectResult,
   savedObjectId,
 }: {
   creationOptions?: DashboardCreationOptions;
-  incomingEmbeddable?: EmbeddablePackageState | undefined;
+  incomingEmbeddables?: EmbeddablePackageState[] | undefined;
   initialState: DashboardState;
   savedObjectResult?: LoadDashboardReturn;
   savedObjectId?: string;
@@ -58,7 +60,7 @@ export function getDashboardApi({
   const isManaged = savedObjectResult?.managed ?? false;
   const savedObjectId$ = new BehaviorSubject<string | undefined>(savedObjectId);
 
-  const viewModeManager = initializeViewModeManager(incomingEmbeddable, savedObjectResult);
+  const viewModeManager = initializeViewModeManager(incomingEmbeddables, savedObjectResult);
   const trackPanel = initializeTrackPanel(async (id: string) => {
     await layoutManager.api.getChildApi(id);
   });
@@ -71,14 +73,23 @@ export function getDashboardApi({
     return getReferencesForPanelId(id, references$.value ?? []);
   };
 
+  const incomingControlGroup = incomingEmbeddables?.find(
+    (embeddable) => embeddable.type === CONTROLS_GROUP_TYPE
+  );
+  const restEmbeddables = incomingEmbeddables?.filter(
+    (embeddable) => embeddable.type !== CONTROLS_GROUP_TYPE
+  );
+
   const layoutManager = initializeLayoutManager(
-    incomingEmbeddable,
+    restEmbeddables,
     initialState.panels,
     trackPanel,
     getReferences
   );
+  const incomingControlGroupState = incomingControlGroup?.serializedState
+    .rawState as ControlsGroupState;
   const controlGroupManager = initializeControlGroupManager(
-    initialState.controlGroupInput,
+    incomingControlGroupState ?? initialState.controlGroupInput,
     getReferences
   );
   const dataLoadingManager = initializeDataLoadingManager(layoutManager.api.children$);
@@ -227,7 +238,7 @@ export function getDashboardApi({
 
   const searchSessionManager = initializeSearchSessionManager(
     creationOptions?.searchSessionSettings,
-    incomingEmbeddable,
+    incomingEmbeddables,
     dashboardApi,
     internalApi
   );

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/load_dashboard_api/load_dashboard_api.ts
@@ -27,7 +27,7 @@ export async function loadDashboardApi({
 }) {
   const creationStartTime = performance.now();
   const creationOptions = await getCreationOptions?.();
-  const incomingEmbeddable = creationOptions?.getIncomingEmbeddable?.();
+  const incomingEmbeddables = creationOptions?.getIncomingEmbeddables?.();
   const savedObjectResult = await getDashboardContentManagementService().loadDashboardState({
     id: savedObjectId,
   });
@@ -78,7 +78,7 @@ export async function loadDashboardApi({
   // --------------------------------------------------------------------------------------
   const { api, cleanup, internalApi } = getDashboardApi({
     creationOptions,
-    incomingEmbeddable,
+    incomingEmbeddables,
     initialState: {
       ...combinedSessionState,
       ...overrideState,
@@ -92,7 +92,7 @@ export async function loadDashboardApi({
     creationStartTime,
   });
 
-  if (savedObjectId && !incomingEmbeddable) {
+  if (savedObjectId && !incomingEmbeddables) {
     // We count a new view every time a user opens a dashboard, both in view or edit mode
     // We don't count views when a user is editing a dashboard and is returning from an editor after saving
     // however, there is an edge case that we now count a new view when a user is editing a dashboard and is returning from an editor by canceling

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/search_sessions/search_session_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/search_sessions/search_session_manager.ts
@@ -15,7 +15,7 @@ import { startDashboardSearchSessionIntegration } from './start_dashboard_search
 
 export function initializeSearchSessionManager(
   searchSessionSettings: DashboardCreationOptions['searchSessionSettings'],
-  incomingEmbeddable: EmbeddablePackageState | undefined,
+  incomingEmbeddables: EmbeddablePackageState[] | undefined,
   dashboardApi: Omit<DashboardApi, 'searchSessionId$'>,
   dashboardInternalApi: DashboardInternalApi
 ) {
@@ -26,9 +26,11 @@ export function initializeSearchSessionManager(
     const { sessionIdToRestore } = searchSessionSettings;
 
     // if this incoming embeddable has a session, continue it.
-    if (incomingEmbeddable?.searchSessionId) {
-      dataService.search.session.continue(incomingEmbeddable.searchSessionId);
-    }
+    incomingEmbeddables?.forEach((embeddablePackage) => {
+      if (embeddablePackage.searchSessionId) {
+        dataService.search.session.continue(embeddablePackage.searchSessionId);
+      }
+    });
     if (sessionIdToRestore) {
       dataService.search.session.restore(sessionIdToRestore);
     }
@@ -36,7 +38,7 @@ export function initializeSearchSessionManager(
 
     const initialSearchSessionId =
       sessionIdToRestore ??
-      (existingSession && incomingEmbeddable
+      (existingSession && incomingEmbeddables
         ? existingSession
         : dataService.search.session.start());
     searchSessionId$.next(initialSearchSessionId);

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/types.ts
@@ -61,7 +61,7 @@ export const ReservedLayoutItemTypes: readonly string[] = ['section'] as const;
 export interface DashboardCreationOptions {
   getInitialInput?: () => Partial<DashboardState & { viewMode?: ViewMode }>;
 
-  getIncomingEmbeddable?: () => EmbeddablePackageState | undefined;
+  getIncomingEmbeddables?: () => EmbeddablePackageState[] | undefined;
 
   useSearchSessionsIntegration?: boolean;
   searchSessionSettings?: {

--- a/src/platform/plugins/shared/dashboard/public/dashboard_api/view_mode_manager.ts
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_api/view_mode_manager.ts
@@ -15,7 +15,7 @@ import { getDashboardBackupService } from '../services/dashboard_backup_service'
 import { getDashboardCapabilities } from '../utils/get_dashboard_capabilities';
 
 export function initializeViewModeManager(
-  incomingEmbeddable?: EmbeddablePackageState,
+  incomingEmbeddables?: EmbeddablePackageState[],
   savedObjectResult?: LoadDashboardReturn
 ) {
   const dashboardBackupService = getDashboardBackupService();
@@ -25,7 +25,7 @@ export function initializeViewModeManager(
     }
 
     if (
-      incomingEmbeddable ||
+      incomingEmbeddables ||
       savedObjectResult?.newDashboardCreated ||
       dashboardBackupService.dashboardHasUnsavedEdits(savedObjectResult?.dashboardId)
     )

--- a/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
+++ b/src/platform/plugins/shared/dashboard/public/dashboard_app/dashboard_app.tsx
@@ -67,7 +67,7 @@ export function DashboardApp({
 }: DashboardAppProps) {
   const [showNoDataPage, setShowNoDataPage] = useState<boolean>(false);
   const [regenerateId, setRegenerateId] = useState(uuidv4());
-  const incomingEmbeddable = useMemo(() => {
+  const incomingEmbeddables = useMemo(() => {
     return embeddableService
       .getStateTransfer()
       .getIncomingEmbeddablePackage(DASHBOARD_APP_ID, true);
@@ -76,7 +76,7 @@ export function DashboardApp({
   useEffect(() => {
     let canceled = false;
     // show dashboard when there is an incoming embeddable
-    if (incomingEmbeddable) {
+    if (incomingEmbeddables && incomingEmbeddables.length > 0) {
       return;
     }
 
@@ -93,7 +93,7 @@ export function DashboardApp({
     return () => {
       canceled = true;
     };
-  }, [incomingEmbeddable]);
+  }, [incomingEmbeddables]);
   const [dashboardApi, setDashboardApi] = useState<DashboardApi | undefined>(undefined);
 
   const showPlainSpinner = useObservable(coreServices.customBranding.hasCustomBranding$, false);
@@ -171,7 +171,7 @@ export function DashboardApp({
     };
 
     return Promise.resolve<DashboardCreationOptions>({
-      getIncomingEmbeddable: () => incomingEmbeddable,
+      getIncomingEmbeddables: () => incomingEmbeddables,
 
       // integrations
       useSessionStorageIntegration: true,
@@ -204,7 +204,7 @@ export function DashboardApp({
     validateOutcome,
     getScopedHistory,
     kbnUrlStateStorage,
-    incomingEmbeddable,
+    incomingEmbeddables,
   ]);
 
   useEffect(() => {

--- a/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/components/chart/use_discover_histogram.ts
@@ -210,6 +210,7 @@ export const useDiscoverHistogram = (
    */
   const { query, filters } = useQuerySubscriber({ data: services.data });
   const requestParams = useCurrentTabSelector((state) => state.dataRequestParams);
+  const currentTabControlState = useCurrentTabSelector((tab) => tab.controlGroupState);
   const {
     timeRangeRelative: relativeTimeRange,
     timeRangeAbsolute: timeRange,
@@ -418,6 +419,7 @@ export const useDiscoverHistogram = (
     onVisContextChanged: isEsqlMode ? onVisContextChanged : undefined,
     breakdownField,
     esqlVariables,
+    controlsState: currentTabControlState,
     onBreakdownFieldChange,
     searchSessionId,
     getModifiedVisAttributes,

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.test.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.test.ts
@@ -225,10 +225,12 @@ describe('embeddable state transfer', () => {
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
-    expect(fetchedState).toEqual({
-      type: 'skisEmbeddable',
-      serializedState: { rawState: { savedObjectId: '123' } },
-    });
+    expect(fetchedState).toEqual([
+      {
+        type: 'skisEmbeddable',
+        serializedState: { rawState: { savedObjectId: '123' } },
+      },
+    ]);
   });
 
   it('can fetch an incoming embeddable package state and ignore state for other apps', async () => {
@@ -245,16 +247,20 @@ describe('embeddable state transfer', () => {
       },
     });
     const fetchedState = stateTransfer.getIncomingEmbeddablePackage(testAppId);
-    expect(fetchedState).toEqual({
-      type: 'skisEmbeddable',
-      serializedState: { rawState: { savedObjectId: '123' } },
-    });
+    expect(fetchedState).toEqual([
+      {
+        type: 'skisEmbeddable',
+        serializedState: { rawState: { savedObjectId: '123' } },
+      },
+    ]);
 
     const fetchedState2 = stateTransfer.getIncomingEmbeddablePackage('testApp2');
-    expect(fetchedState2).toEqual({
-      type: 'crossCountryEmbeddable',
-      serializedState: { rawState: { savedObjectId: '456' } },
-    });
+    expect(fetchedState2).toEqual([
+      {
+        type: 'crossCountryEmbeddable',
+        serializedState: { rawState: { savedObjectId: '456' } },
+      },
+    ]);
   });
 
   it('embeddable package state returns undefined when state is not in the right shape', async () => {

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
@@ -137,6 +137,7 @@ export class EmbeddableStateTransfer {
     appId: string,
     options?: { path?: string; state: EmbeddablePackageState<SerializedStateType> }
   ): Promise<void> {
+    console.log('navigateToWithEmbeddablePackage');
     this.isTransferInProgress = true;
     await this.navigateToWithState<EmbeddablePackageState<SerializedStateType>>(
       appId,

--- a/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
+++ b/src/platform/plugins/shared/embeddable/public/state_transfer/embeddable_state_transfer.ts
@@ -99,8 +99,8 @@ export class EmbeddableStateTransfer {
   public getIncomingEmbeddablePackage(
     appId: string,
     removeAfterFetch?: boolean
-  ): EmbeddablePackageState | undefined {
-    return this.getIncomingState<EmbeddablePackageState>(
+  ): EmbeddablePackageState[] | undefined {
+    return this.getIncomingState1<EmbeddablePackageState>(
       isEmbeddablePackageState,
       appId,
       EMBEDDABLE_PACKAGE_STATE_KEY,
@@ -137,7 +137,6 @@ export class EmbeddableStateTransfer {
     appId: string,
     options?: { path?: string; state: EmbeddablePackageState<SerializedStateType> }
   ): Promise<void> {
-    console.log('navigateToWithEmbeddablePackage');
     this.isTransferInProgress = true;
     await this.navigateToWithState<EmbeddablePackageState<SerializedStateType>>(
       appId,
@@ -146,6 +145,39 @@ export class EmbeddableStateTransfer {
         ...options,
       }
     );
+  }
+
+  /**
+   * A wrapper around the {@link ApplicationStart.navigateToApp} method which navigates to the specified appId
+   * with multiple {@link EmbeddablePackageState | embeddable package state}
+   */
+  public async navigateToWithMultipleEmbeddablePackage<SerializedStateType extends object = object>(
+    appId: string,
+    options?: { path?: string; state: Array<EmbeddablePackageState<SerializedStateType>> }
+  ): Promise<void> {
+    this.isTransferInProgress = true;
+    await this.navigateToWithState<Array<EmbeddablePackageState<SerializedStateType>>>(
+      appId,
+      EMBEDDABLE_PACKAGE_STATE_KEY,
+      {
+        ...options,
+      }
+    );
+  }
+
+  private removeKeysFromStorage(
+    state: Record<string, any>,
+    options?: {
+      keysToRemoveAfterFetch?: string[];
+    }
+  ): void {
+    if (options?.keysToRemoveAfterFetch?.length) {
+      const stateReplace = { ...state };
+      options.keysToRemoveAfterFetch.forEach((keyToRemove: string) => {
+        delete stateReplace[keyToRemove];
+      });
+      this.storage.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, stateReplace);
+    }
   }
 
   private getIncomingState<IncomingStateType>(
@@ -167,6 +199,45 @@ export class EmbeddableStateTransfer {
       this.storage.set(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY, stateReplace);
     }
     return castState;
+  }
+
+  private getIncomingState1<IncomingStateType>(
+    guard: (state: unknown) => state is IncomingStateType,
+    appId: string,
+    key: string,
+    options?: {
+      keysToRemoveAfterFetch?: string[];
+    }
+  ): IncomingStateType[] | undefined {
+    const embeddableState = this.storage.get(EMBEDDABLE_STATE_TRANSFER_STORAGE_KEY);
+    if (!embeddableState) {
+      return undefined;
+    }
+
+    const incomingState = embeddableState[key]?.[appId];
+
+    if (!incomingState) {
+      return undefined;
+    }
+
+    // Handle array case: collect all valid states that pass the guard
+    if (Array.isArray(incomingState)) {
+      const validStates = incomingState.filter((item) => guard(item));
+      if (validStates.length > 0) {
+        this.removeKeysFromStorage(embeddableState, options);
+        return validStates.map((item) => cloneDeep(item) as IncomingStateType);
+      }
+      return undefined;
+    }
+
+    // Handle single item case
+    if (guard(incomingState)) {
+      this.removeKeysFromStorage(embeddableState, options);
+      return [cloneDeep(incomingState)];
+    }
+
+    // Return undefined if neither case is a match
+    return undefined;
   }
 
   private async navigateToWithState<OutgoingStateType = unknown>(

--- a/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
+++ b/x-pack/platform/plugins/shared/cases/public/components/markdown_editor/plugins/lens/plugin.tsx
@@ -246,13 +246,14 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
     if (currentAppId) {
       incomingEmbeddablePackage = embeddable
         ?.getStateTransfer()
-        .getIncomingEmbeddablePackage(currentAppId, true) as LensIncomingEmbeddablePackage;
+        .getIncomingEmbeddablePackage(currentAppId, true);
     }
 
-    if (
-      incomingEmbeddablePackage?.type === 'lens' &&
-      incomingEmbeddablePackage?.serializedState?.rawState?.attributes
-    ) {
+    const lensEmbeddablePackage = incomingEmbeddablePackage?.find(
+      (pkg) => pkg.type === 'lens'
+    ) as LensIncomingEmbeddablePackage;
+
+    if (lensEmbeddablePackage && lensEmbeddablePackage?.serializedState?.rawState?.attributes) {
       const lensTime = timefilter.getTime();
       const newTimeRange =
         lensTime?.from && lensTime?.to
@@ -267,7 +268,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
 
       if (draftComment?.position) {
         handleUpdate(
-          incomingEmbeddablePackage.serializedState.rawState.attributes,
+          lensEmbeddablePackage.serializedState.rawState.attributes,
           newTimeRange,
           draftComment.position
         );
@@ -275,7 +276,7 @@ const LensEditorComponent: LensEuiMarkdownEditorUiPlugin['editor'] = ({
       }
 
       if (draftComment) {
-        handleAdd(incomingEmbeddablePackage.serializedState.rawState.attributes, newTimeRange);
+        handleAdd(lensEmbeddablePackage.serializedState.rawState.attributes, newTimeRange);
       }
     }
   }, [embeddable, storage, timefilter, currentAppId, handleAdd, handleUpdate, draftComment]);

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container.tsx
@@ -12,6 +12,7 @@ import { VisualizeFieldContext } from '@kbn/ui-actions-plugin/public';
 import type { Reference } from '@kbn/content-management-utils';
 import { EuiLoadingSpinner } from '@elastic/eui';
 import { omit } from 'lodash';
+import type { ControlPanelsState } from '@kbn/controls-plugin/common';
 import { SaveModal } from './save_modal';
 import type { LensAppProps, LensAppServices } from './types';
 import type { SaveProps } from './app';
@@ -37,6 +38,7 @@ export type SaveModalContainerProps = {
   returnToOriginSwitchLabel?: string;
   onClose: () => void;
   onSave?: (saveProps: SaveProps) => void;
+  controlsInput?: ControlPanelsState;
   runSave?: (saveProps: SaveProps, options: { saveToLibrary: boolean }) => void;
   isSaveable?: boolean;
   getAppNameFromId?: () => string | undefined;
@@ -78,6 +80,7 @@ export function SaveModalContainer({
   lensServices,
   initialContext,
   managed,
+  controlsInput,
 }: SaveModalContainerProps) {
   let title = '';
   let description;
@@ -148,6 +151,7 @@ export function SaveModalContainer({
           redirectToOrigin,
           originatingApp,
           getOriginatingPath,
+          controlsInput,
           onAppLeave: () => {},
           ...lensServices,
         },
@@ -232,6 +236,7 @@ export type SaveVisualizationProps = Simplify<
     textBasedLanguageSave?: boolean;
     switchDatasource?: () => void;
     lensDocumentService: LensDocumentService;
+    controlsInput?: ControlPanelsState;
   } & ExtraProps &
     Pick<
       LensAppServices,
@@ -270,6 +275,7 @@ export const runSaveLensVisualization = async (
     switchDatasource,
     application,
     lensDocumentService,
+    controlsInput,
   } = props;
 
   if (!lastKnownDoc) {
@@ -373,6 +379,7 @@ export const runSaveLensVisualization = async (
         stateTransfer,
         originatingApp: props.originatingApp,
         getOriginatingPath: props.getOriginatingPath,
+        controlsInput,
       });
       return;
     }

--- a/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container_helpers.ts
+++ b/x-pack/platform/plugins/shared/lens/public/app_plugin/save_modal_container_helpers.ts
@@ -4,8 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { v4 as generateId } from 'uuid';
 import { EmbeddableStateWithType } from '@kbn/embeddable-plugin/common';
+import type { ControlPanelsState } from '@kbn/controls-plugin/common';
+import type { ControlsGroupState } from '@kbn/controls-schemas';
+import {
+  DEFAULT_CONTROLS_CHAINING,
+  DEFAULT_CONTROLS_LABEL_POSITION,
+  DEFAULT_IGNORE_PARENT_SETTINGS,
+  DEFAULT_AUTO_APPLY_SELECTIONS,
+} from '@kbn/controls-constants';
+import { CONTROLS_GROUP_TYPE } from '@kbn/controls-constants';
 import type { LensAppServices } from './types';
 import { LENS_EMBEDDABLE_TYPE } from '../../common/constants';
 import { extract } from '../../common/embeddable_factory';
@@ -17,26 +26,69 @@ export const redirectToDashboard = ({
   originatingApp,
   getOriginatingPath,
   stateTransfer,
+  controlsInput,
 }: {
   embeddableInput: LensSerializedState;
   dashboardId: string;
   originatingApp?: string;
+  controlsInput?: ControlPanelsState;
   getOriginatingPath?: (dashboardId: string) => string | undefined;
   stateTransfer: LensAppServices['stateTransfer'];
 }) => {
   const { references } = extract(rawState as unknown as EmbeddableStateWithType);
 
   const appId = originatingApp || 'dashboards';
-  stateTransfer.navigateToWithEmbeddablePackage<LensSerializedState>(appId, {
-    state: {
-      type: LENS_EMBEDDABLE_TYPE,
-      serializedState: {
-        rawState,
-        references,
-      },
-    },
-    path:
-      getOriginatingPath?.(dashboardId) ??
-      (dashboardId === 'new' ? '#/create' : `#/view/${dashboardId}`),
+  // const controls: {
+  //   type: string;
+  //   serializedState: { rawState: ControlPanelState<DefaultControlState> };
+  // }[] = [];
+  const controls: ControlsGroupState['controls'] = [];
+  Object.values(controlsInput ?? {}).forEach((panel, idx) => {
+    const { width, grow, type, ...controlConfig } = panel;
+    const id = generateId();
+    // controls.push({
+    //   type: CONTROLS_GROUP_TYPE,
+    //   serializedState: {
+    //     rawState: panel,
+    //   },
+    // });
+    controls.push({
+      id,
+      grow,
+      order: idx,
+      type,
+      width,
+      controlConfig,
+    });
   });
+  stateTransfer.navigateToWithMultipleEmbeddablePackage<LensSerializedState | ControlsGroupState>(
+    appId,
+    {
+      state: [
+        {
+          type: LENS_EMBEDDABLE_TYPE,
+          serializedState: {
+            rawState,
+            references,
+          },
+        },
+        {
+          type: CONTROLS_GROUP_TYPE,
+          serializedState: {
+            rawState: {
+              labelPosition: DEFAULT_CONTROLS_LABEL_POSITION,
+              chainingSystem: DEFAULT_CONTROLS_CHAINING,
+              autoApplySelections: DEFAULT_AUTO_APPLY_SELECTIONS,
+              ignoreParentSettings: DEFAULT_IGNORE_PARENT_SETTINGS,
+              controls,
+            },
+            references: [],
+          },
+        },
+      ],
+      path:
+        getOriginatingPath?.(dashboardId) ??
+        (dashboardId === 'new' ? '#/create' : `#/view/${dashboardId}`),
+    }
+  );
 };

--- a/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/dashboards/components/dashboard_renderer.tsx
@@ -112,8 +112,12 @@ const DashboardRendererComponent = ({
       getInitialInput: () => {
         return initialInput.value;
       },
-      getIncomingEmbeddable: () =>
-        embeddable.getStateTransfer().getIncomingEmbeddablePackage(APP_UI_ID, true),
+      getIncomingEmbeddables: () => {
+        const incoming = embeddable
+          .getStateTransfer()
+          .getIncomingEmbeddablePackage(APP_UI_ID, true);
+        return incoming;
+      },
       getEmbeddableAppContext: (dashboardId?: string) => ({
         getCurrentPath: () =>
           dashboardId ? `${DASHBOARDS_PATH}/${dashboardId}/edit` : `${DASHBOARDS_PATH}/create`,


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)