### PR TITLE
Gate custom content guidance in dashboard skill content

### DIFF
--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/plugin.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/plugin.test.ts
@@ -9,27 +9,36 @@ import { coreMock } from '@kbn/core/server/mocks';
 import { AgentBuilderDashboardsPlugin } from './plugin';
 
 describe('AgentBuilderDashboardsPlugin', () => {
-  it('registers the dashboard attachment type, skill, and SML type', () => {
+  it('registers the dashboard attachment type, skill, and SML type', async () => {
     const registerAttachmentType = jest.fn();
     const registerSkill = jest.fn();
     const registerSmlType = jest.fn();
+    const getBooleanValue = jest.fn().mockResolvedValue(true);
 
     const plugin = new AgentBuilderDashboardsPlugin(coreMock.createPluginInitializerContext());
-
-    plugin.setup(
-      {} as never,
+    const coreSetup = coreMock.createSetup();
+    coreSetup.getStartServices.mockResolvedValue([
       {
-        agentBuilder: {
-          attachments: { registerType: registerAttachmentType },
-          skills: { register: registerSkill },
-        },
-        agentBuilderSml: {
-          registerType: registerSmlType,
-        },
-      } as never
-    );
+        featureFlags: { getBooleanValue },
+      },
+      {},
+      {},
+    ] as never);
+
+    plugin.setup(coreSetup as never, {
+      agentBuilder: {
+        attachments: { registerType: registerAttachmentType },
+        skills: { register: registerSkill },
+      },
+      agentBuilderSml: {
+        registerType: registerSmlType,
+      },
+    } as never);
+
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(registerAttachmentType).toHaveBeenCalledTimes(1);
+    expect(getBooleanValue).toHaveBeenCalled();
     expect(registerSkill).toHaveBeenCalledTimes(1);
     expect(registerSkill).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'dashboard-management' })

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/plugin.ts
@@ -57,10 +57,16 @@ export class AgentBuilderDashboardsPlugin
       }) as Parameters<typeof setupDeps.agentBuilder.attachments.registerType>[0]
     );
     setupDeps.agentBuilderSml.registerType(createDashboardSmlType({ getDashboardClient }));
-    registerSkills(setupDeps.agentBuilder, async () => {
+
+    (async () => {
       const [coreStart] = await coreSetup.getStartServices();
-      return coreStart.featureFlags.getBooleanValue(CUSTOM_CONTENT_ENABLED_FLAG_KEY, false);
-    });
+      const customContentEnabled = await coreStart.featureFlags.getBooleanValue(
+        CUSTOM_CONTENT_ENABLED_FLAG_KEY,
+        false
+      );
+      registerSkills(setupDeps.agentBuilder, customContentEnabled);
+    })();
+
     return {};
   }
 

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/dashboard_management_skill.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/dashboard_management_skill.ts
@@ -7,11 +7,13 @@
 
 import { defineSkillType } from '@kbn/agent-builder-server/skills/type_definition';
 import { generateDashboardTool } from '../tools';
-import { dashboardGeneration } from './generation_guidance';
+import { createDashboardGeneration } from './generation_guidance';
 import { kibanaRendering } from './rendering_guidance';
 
-export const createDashboardManagementSkill = (getCustomContentEnabled: () => Promise<boolean>) =>
-  defineSkillType({
+export const createDashboardManagementSkill = (customContentEnabled: boolean) => {
+  const dashboardGeneration = createDashboardGeneration(customContentEnabled);
+
+  return defineSkillType({
     id: 'dashboard-management',
     name: 'dashboard-management',
     basePath: 'skills/platform/dashboard',
@@ -37,8 +39,6 @@ ${kibanaRendering.guidance}
       ...(dashboardGeneration.referencedContent ?? []),
       ...(kibanaRendering.referencedContent ?? []),
     ],
-    getInlineTools: async () => {
-      const customContentEnabled = await getCustomContentEnabled();
-      return [generateDashboardTool({ customContentEnabled })];
-    },
+    getInlineTools: () => [generateDashboardTool()],
   });
+};

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/generation_guidance.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/generation_guidance.ts
@@ -12,7 +12,42 @@ import { dashboardDesignGuidancePrompt } from './design';
 
 const chartTypeSelectionGuidance = getChartTypeSelectionPromptContent();
 
-const guidance = `## Building a Dashboard
+const customContentPanelTypeSelection = `4. **Custom content** (\`source: "config"\`, \`type: "custom_content"\`) — **last resort** for content that cannot be expressed as a chart or plain markdown. Typical use cases: KPI scorecards with colored status badges, health/status boards, mixed text-and-data layouts, or panels that combine multiple metrics in a custom HTML structure.
+
+**When to use custom content:**
+- The content needs an HTML/CSS layout that no single Lens chart type can express (e.g. a colored status grid, a scorecard with large KPI numbers and trend badges).
+- The panel mixes narrative text with live data values in a single view.
+- The user explicitly asks for a custom or HTML-based panel.
+
+**When NOT to use custom content:**
+- Any standard time series, bar, pie, metric, or data table → use Lens.
+- Scatter plots, faceted charts, layered charts, combination charts → use Vega.
+- Plain explanatory text with no data → use markdown.
+
+**Creating a custom content panel:**
+- Set \`config.prompt\` to a concise description of what to display. Do not supply \`template\` on create — the embeddable generates a visually consistent HTML template using EUI color tokens for the active theme.
+- Optionally set \`config.esqlQuery\` when the panel needs live data.
+
+**Editing a custom content panel:**
+- Use \`edit_panels\` (\`source: "config"\`, \`type: "custom_content"\`) and set \`panelId\` to the target panel.
+- Always carry over \`prompt\`, \`template\`, and \`esqlQuery\` from the existing panel config — only modify the fields the user is changing.
+- Modify \`template\` in place (targeted edits, not a full rewrite) so the changes are consistent with the existing EUI color scheme. Omit \`template\` only if the user wants a full regeneration from the updated prompt.
+`;
+
+/**
+ * Environment-agnostic dashboard *generation* guidance.
+ *
+ * The `guidance` describes how to build a dashboard, including the detailed design guidance
+ * (composition + panel layout) inlined directly. It deliberately says nothing about how the
+ * current dashboard is referenced or how the result is returned/surfaced. Those are
+ * environment-specific and avoided here so the block can be reused across environments. Pair it with
+ * an environment-specific rendering guidance block (e.g. the Kibana one) that explains how the
+ * generated dashboard is surfaced.
+ */
+export const createDashboardGeneration = (
+  customContentEnabled: boolean
+): DashboardGuidanceModule => ({
+  guidance: `## Building a Dashboard
 
 The ${dashboardTools.generateDashboard} tool builds the resulting dashboard from the current dashboard (if any) plus an ordered \`operations\` array. This section describes the \`operations\` vocabulary; see the environment workflow below for how the current dashboard is referenced and how the result is surfaced.
 
@@ -37,7 +72,9 @@ For an existing dashboard:
 ## Panel Inputs
 
 - Use \`source: "request"\` to create or edit a Lens or Vega panel from a natural-language / ES|QL query — this is the only correct way to make a **new** visualization. Never hand-build a visualization \`config\` for a new visualization.
-- Use \`source: "config"\` only for content you have already resolved (an existing visualization's config or markdown). The generation tool never reads an attachment or saved-object store, so the config must be supplied directly.
+- Use \`source: "config"\` only for content you have already resolved (an existing visualization's config or markdown${
+    customContentEnabled ? ', or custom content' : ''
+  }). The generation tool never reads an attachment or saved-object store, so the config must be supplied directly.
 
 ## Panel Type Selection
 
@@ -46,8 +83,7 @@ Choose the panel type in this priority order:
 1. **Lens** (\`source: "request"\`, \`renderer: "lens"\` or omit renderer) — default for metric, time series, bar, line, pie, area, and data table visualizations.
 2. **Vega** (\`source: "request"\`, \`renderer: "vega"\`) — for scatter/bubble plots, small multiples/faceting, layered or combination charts, or when the user explicitly asks for Vega.
 3. **Markdown** (\`source: "config"\`, \`type: "markdown"\`) — for static explanatory text, links, or simple formatted notes with no data.
-4. **Custom content** (\`source: "config"\`, \`type: "custom_content"\`) — only if listed under "Use operations[] to" in the tool description. When available, use it as a last resort for HTML-based layouts that Lens and Vega cannot express.
-
+${customContentEnabled ? customContentPanelTypeSelection : ''}
 ## Chart Type Guidance
 
 For every new Lens panel, choose and pass \`chartType\`; it is required. For a new Vega panel, \`chartType\` is an optional authoring hint — omit it when no Lens chart type represents the requested visualization. On edits, \`chartType\` is optional because the existing panel configuration provides the current visual form. When editing a Lens panel, omit \`chartType\` to preserve its current chart family; provide a new \`chartType\` when the request changes the chart family, such as from \`xy\` to \`pie\`.
@@ -87,21 +123,12 @@ Do not add controls to dashboards already scoped to a single entity (one host, o
 
 - Never invent a \`source: "config"\` payload for content you have not actually resolved. If you cannot obtain a panel's configuration, report it clearly instead of fabricating one.
 - Use \`update_panel_layouts\` when the user wants to resize, reposition, or move panels without changing panel content.
-- If a user wants to change a dashboard panel's content, prefer \`edit_panels\` over removing and re-adding the panel. \`edit_panels\` works for ES|QL-backed Lens visualization panels (\`source: "request"\`) and markdown panels (\`source: "config"\`, \`type: "markdown"\`). Additional panel types may be supported — check the tool description for the current list.
+- If a user wants to change a dashboard panel's content, prefer \`edit_panels\` over removing and re-adding the panel. \`edit_panels\` works for ES|QL-backed Lens visualization panels (\`source: "request"\`) and markdown panels (\`source: "config"\`, \`type: "markdown"\`)${
+    customContentEnabled
+      ? ', and custom content panels (`source: "config"`, `type: "custom_content"`)'
+      : ''
+  }.
 - A dashboard can include DSL-based, form-based, or other non-ES|QL Lens panels. Do not attempt to edit those panels directly.
 - If the user asks to modify a DSL visualization or any other non-ES|QL panel, explicitly explain that direct editing is not supported, propose recreating and replacing it as a new ES|QL-based Lens chart, and ask for confirmation before you remove or replace the existing panel.
-- Never silently follow a remove-and-recreate flow for a non-ES|QL panel. Wait for explicit user confirmation before regenerating the dashboard with replacement operations.`;
-
-/**
- * Environment-agnostic dashboard *generation* guidance.
- *
- * The `guidance` describes how to build a dashboard, including the detailed design guidance
- * (composition + panel layout) inlined directly. It deliberately says nothing about how the
- * current dashboard is referenced or how the result is returned/surfaced. Those are
- * environment-specific and avoided here so the block can be reused across environments. Pair it with
- * an environment-specific rendering guidance block (e.g. the Kibana one) that explains how the
- * generated dashboard is surfaced.
- */
-export const dashboardGeneration: DashboardGuidanceModule = {
-  guidance,
-};
+- Never silently follow a remove-and-recreate flow for a non-ES|QL panel. Wait for explicit user confirmation before regenerating the dashboard with replacement operations.`,
+});

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/index.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/generation_guidance/index.ts
@@ -5,4 +5,4 @@
  * 2.0.
  */
 
-export { dashboardGeneration } from './generation_guidance';
+export { createDashboardGeneration } from './generation_guidance';

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.test.ts
@@ -9,7 +9,7 @@ import type { AgentBuilderPluginSetup } from '@kbn/agent-builder-server';
 import { createDashboardManagementSkill } from './dashboard_management_skill';
 import { registerSkills } from './register_skills';
 
-const skill = createDashboardManagementSkill(() => Promise.resolve(true));
+const skill = createDashboardManagementSkill(false);
 
 describe('registerSkills', () => {
   it('registers the dashboard management skill', async () => {
@@ -18,7 +18,7 @@ describe('registerSkills', () => {
       skills: { register },
     } as unknown as AgentBuilderPluginSetup;
 
-    await registerSkills(agentBuilder, () => Promise.resolve(true));
+    registerSkills(agentBuilder, false);
 
     expect(register).toHaveBeenCalledTimes(1);
     expect(register).toHaveBeenCalledWith(expect.objectContaining({ id: 'dashboard-management' }));
@@ -44,5 +44,19 @@ describe('registerSkills', () => {
     expect(skill.content).toContain(
       'provide a new `chartType` when the request changes the chart family'
     );
+  });
+
+  it('omits custom content guidance when the feature flag is disabled', () => {
+    expect(skill.content).not.toContain('type: "custom_content"');
+    expect(skill.content).not.toContain('When to use custom content:');
+  });
+
+  it('includes custom content guidance when the feature flag is enabled', () => {
+    const enabledSkill = createDashboardManagementSkill(true);
+
+    expect(enabledSkill.content).toContain('type: "custom_content"');
+    expect(enabledSkill.content).toContain('When to use custom content:');
+    expect(enabledSkill.content).toContain('Creating a custom content panel:');
+    expect(enabledSkill.content).toContain('Editing a custom content panel:');
   });
 });

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/skills/register_skills.ts
@@ -10,7 +10,7 @@ import { createDashboardManagementSkill } from './dashboard_management_skill';
 
 export const registerSkills = (
   agentBuilder: AgentBuilderPluginSetup,
-  getCustomContentEnabled: () => Promise<boolean>
+  customContentEnabled: boolean
 ): void => {
-  agentBuilder.skills.register(createDashboardManagementSkill(getCustomContentEnabled));
+  agentBuilder.skills.register(createDashboardManagementSkill(customContentEnabled));
 };

--- a/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/generate_dashboard_tool.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_dashboards/server/tools/generate/generate_dashboard_tool.ts
@@ -99,28 +99,7 @@ const summarizeDashboard = (
  * This keeps the heavy payload out of the LLM transcript — the model references
  * the attachment id to render it rather than copying it into the next tool call.
  */
-const CUSTOM_CONTENT_TOOL_GUIDANCE = `
-8. add / edit custom content panels (\`source: "config"\`, \`type: "custom_content"\`) for HTML-based layouts that Lens and Vega cannot express, such as KPI scorecards with colored status badges, health/status boards, or panels that mix narrative text with live data values.
-
-**Custom content panel type selection:**
-Use custom content only as a last resort:
-- Any standard time series, bar, pie, metric, or data table → use Lens.
-- Scatter plots, faceted charts, layered charts, combination charts → use Vega.
-- Plain explanatory text with no data → use markdown.
-- The content needs an HTML/CSS layout no single Lens chart type can express, or mixes narrative text with live data, or the user explicitly asks for a custom/HTML panel → use custom content.
-
-**Creating a custom content panel:**
-- Set \`config.prompt\` to a concise description of what to display. Do not supply \`template\` on create — the embeddable generates a visually consistent HTML template using EUI color tokens for the active theme.
-- Optionally set \`config.esqlQuery\` when the panel needs live data.
-
-**Editing a custom content panel:**
-- Use \`edit_panels\` (\`source: "config"\`, \`type: "custom_content"\`) and set \`panelId\` to the target panel.
-- Always carry over \`prompt\`, \`template\`, and \`esqlQuery\` from the existing panel config — only modify the fields the user is changing.
-- Modify \`template\` in place (targeted edits, not a full rewrite) so the changes are consistent with the existing EUI color scheme. Omit \`template\` only if the user wants a full regeneration from the updated prompt.`;
-
-export const generateDashboardTool = ({
-  customContentEnabled = true,
-}: { customContentEnabled?: boolean } = {}): BuiltinSkillBoundedTool<
+export const generateDashboardTool = (): BuiltinSkillBoundedTool<
   typeof generateDashboardSchema
 > => {
   return {
@@ -137,9 +116,7 @@ Use operations[] to:
 4. update panel layouts without changing content
 5. add / remove sections, including inline section panels during add_section
 6. remove panels
-7. add / remove controls (interactive filters pinned above the dashboard: dropdown, range slider, or time slider)${
-      customContentEnabled ? CUSTOM_CONTENT_TOOL_GUIDANCE : ''
-    }`,
+7. add / remove controls (interactive filters pinned above the dashboard: dropdown, range slider, or time slider)`,
     schema: generateDashboardSchema,
     handler: async (
       { dashboardAttachmentId: previousAttachmentId, operations },


### PR DESCRIPTION
## Summary
- Resolve `CUSTOM_CONTENT_ENABLED` before registering the dashboard-management skill.
- When the flag is enabled, include custom content instructions in skill generation guidance instead of appending them to the `generate_dashboard` tool description.
- Revert the tool-level `customContentEnabled` gating from #283952.

Suggested for https://github.com/elastic/kibana/pull/283952 (Addresses #279161).

## Test plan
- [ ] With `dashboard.customContent.enabled: false`, skill content omits custom content guidance
- [ ] With `dashboard.customContent.enabled: true`, skill content includes create/edit custom content guidance
- [ ] `generate_dashboard` tool description no longer mentions custom content conditionally
- [ ] Unit tests in `agent_builder_dashboards` pass for plugin/skill registration


Made with [Cursor](https://cursor.com)